### PR TITLE
Add unit tests

### DIFF
--- a/import.js
+++ b/import.js
@@ -3,9 +3,27 @@ var importStream = require('./src/importStream');
 
 var directory = '../../whosonfirst/whosonfirst-data/';
 
+var types = [
+  'continent',
+  'country',
+  'county',
+  'dependency',
+  'disputed',
+  'empire',
+  'localadmin',
+  'locality',
+  'macrocounty',
+  'macrohood',
+  'macroregion',
+  'metroarea',
+  'microhood',
+  'neighbourhood',
+  'region'
+];
+
 var wofRecords = {};
 
-readStream(directory, wofRecords, function() {
+readStream(directory, types, wofRecords, function() {
   console.log(Object.keys(wofRecords).length + ' records loaded');
 
   importStream(wofRecords);

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "batchflow": "^0.4.0",
     "csv-parse": "^1.0.0",
+    "fs-extra": "^0.26.2",
     "lodash": "^3.10.1",
     "pelias-config": "^1.0.3",
     "pelias-dbclient": "0.0.9",

--- a/src/readStream.js
+++ b/src/readStream.js
@@ -5,25 +5,7 @@ var sink = require('through2-sink');
 
 var readStreamComponents = require('./readStreamComponents');
 
-function readData(directory, wofRecords, callback) {
-  var types = [
-    'continent',
-    'country',
-    'county',
-    'dependency',
-    'disputed',
-    'empire',
-    'localadmin',
-    'locality',
-    'macrocounty',
-    'macrohood',
-    'macroregion',
-    'metroarea',
-    'microhood',
-    'neighbourhood',
-    'region'
-  ];
-
+function readData(directory, types, wofRecords, callback) {
   batch(types).parallel(2).each(function(idx, type, done) {
     var csv_parser = parse({ delimiter: ',', columns: true });
     var is_valid_data_file_path = readStreamComponents.is_valid_data_file_path();

--- a/test/readStreamComponentsTest.js
+++ b/test/readStreamComponentsTest.js
@@ -1,5 +1,6 @@
 var tape = require('tape');
 var event_stream = require('event-stream');
+var fs = require('fs');
 
 var readStreamComponents = require('../src/readStreamComponents');
 
@@ -21,9 +22,64 @@ function test_stream(input, testedStream, callback) {
 }
 
 tape('readStreamComponents', function(test) {
+  test.test('input matching #/#/#/#.geojson pattern should return true, false otherwise', function(t) {
+    var input = [
+      { path: '1/2/3/4.geojson' },
+      { path: 'some text 1/2/3/4.geojson' },
+      { path: 'this is not even remotely valid' },
+      { path: '2/3/4.geojson'},
+      { path: '3/4.geojson' },
+      { path: '4.geojson' }
+    ];
+    var expected = [
+      { path: '1/2/3/4.geojson' },
+      { path: 'some text 1/2/3/4.geojson' }
+    ];
+    var is_valid_data_file_path = readStreamComponents.is_valid_data_file_path();
+
+    test_stream(input, is_valid_data_file_path, function(err, actual) {
+      t.deepEqual(actual, expected, 'should have returned true');
+      t.end();
+    });
+
+  });
+
+  test.test('normalize_file_path should only return id portions of path', function(t) {
+    var input = [
+      { path: '1/2/3/4.geojson' },
+      { path: 'some text 1/2/3/4.geojson' },
+      { path: 'some text/1/2/3/4.geojson' }
+    ];
+    var expected = [
+      '1/2/3/4.geojson',
+      '1/2/3/4.geojson',
+      '1/2/3/4.geojson'
+    ];
+    var normalize_file_path = readStreamComponents.normalize_file_path();
+
+    test_stream(input, normalize_file_path, function(err, actual) {
+      t.deepEqual(actual, expected, 'should have returned true');
+      t.end();
+    });
+
+  });
+
   test.test('filter_incomplete_files_stream filters objects without id and properties', function(t) {
-    var input = [{ id: 5, properties: {}}, { not_id: 6 }];
-    var expected = [{id: 5, properties: {} }];
+    var input = [
+      {
+        id: 5,
+        properties: {}
+      },
+      {
+        not_id: 6
+      }
+    ];
+    var expected = [
+      {
+        id: 5,
+        properties: {}
+      }
+    ];
     var filter_incomplete_files_stream = readStreamComponents.filter_incomplete_files_stream();
 
     test_stream(input, filter_incomplete_files_stream, function(err, actual) {
@@ -31,4 +87,78 @@ tape('readStreamComponents', function(test) {
       t.end();
     });
   });
+
+  test.test('map_fields_stream should return an object with only desired properties', function(t) {
+    var input = [
+      {
+        id: 12345,
+        ignoreField1: 'ignoreField1',
+        ignoreField2: 'ignoreField2',
+        properties: {
+          'wof:name': 'name 1',
+          'wof:placetype': 'place type 1',
+          'wof:parent_id': 'parent id 1',
+          'geom:latitude': 12.121212,
+          'geom:longitude': 21.212121,
+          ignoreField3: 'ignoreField3',
+          ignoreField4: 'ignoreField4',
+        }
+      },
+      {
+        id: 23456,
+        properties: {}
+      }
+    ];
+    var expected = [
+      {
+        id: 12345,
+        name: 'name 1',
+        place_type: 'place type 1',
+        parent_id: 'parent id 1',
+        lat: 12.121212,
+        lon: 21.212121
+      },
+      {
+        id: 23456,
+        name: undefined,
+        place_type: undefined,
+        parent_id: undefined,
+        lat: undefined,
+        lon: undefined
+      }
+    ];
+    var map_fields_stream = readStreamComponents.map_fields_stream();
+
+    test_stream(input, map_fields_stream, function(err, actual) {
+      t.deepEqual(actual, expected, 'stream should contain only objects with id and properties');
+      t.end();
+    });
+
+  });
+
+  test.test('json_parse_stream should parse filename and return parsed object', function(t) {
+    var input = ['parse_stream_test.json'];
+
+    var expected = [{
+      field1: 'value1',
+      field2: 'value2',
+      nested: {
+        field3: 'value3',
+        field4: 'value4'
+      },
+      array: ['value5', 'value6']
+    }];
+
+    fs.writeFileSync(input[0], JSON.stringify(expected[0]) + '\n');
+
+    var json_parse_stream = readStreamComponents.json_parse_stream('./');
+
+    test_stream(input, json_parse_stream, function(err, actual) {
+      t.deepEqual(actual, expected, 'stream should contain only objects with id and properties');
+      t.end();
+      fs.unlinkSync(input[0]);
+    });
+
+  });
+
 });

--- a/test/readStreamTest.js
+++ b/test/readStreamTest.js
@@ -4,27 +4,10 @@ var fs = require('fs-extra');
 
 var readStream = require('../src/readStream');
 
-/*
- * Test a stream with the following process:
- * 1. take input as array
- * 2. turn the array into a stream
- * 3. pipe through stream to be tested
- * 4. pass output of that stream to a callback function
- * 5. assertions can then be made in that callback
- *
- * Callback signature should be something like function callback(error, result)
- */
-function test_stream(input, testedStream, callback) {
-    var input_stream = event_stream.readArray(input);
-    var destination_stream = event_stream.writeArray(callback);
-
-    input_stream.pipe(testedStream).pipe(destination_stream);
-}
-
 tape('readStream', function(test) {
   /*
     this test is not terribly attractive, i'm not happy with it but setup wasn't
-    all that painful. 
+    all that painful.
   */
   test.test('readStream should return from all requested types and populate wofRecords', function(t) {
     // remove tmp directory if for some reason it's been hanging around from a previous run

--- a/test/readStreamTest.js
+++ b/test/readStreamTest.js
@@ -10,53 +10,7 @@ tape('readStream', function(test) {
     all that painful.
   */
   test.test('readStream should return from all requested types and populate wofRecords', function(t) {
-    // remove tmp directory if for some reason it's been hanging around from a previous run
-    fs.removeSync('tmp');
-
-    // shell out since creating multiple levels of directories in node is tedious
-    fs.mkdirsSync('tmp/meta');
-    fs.mkdirsSync('tmp/data/1/2/3');
-    fs.mkdirsSync('tmp/data/5/6/7');
-    fs.mkdirsSync('tmp/data/9/10/11');
-
-    // write out first meta and data files
-    fs.writeFileSync('tmp/meta/wof-type1-latest.csv', 'path\n1/2/3/4.geojson\n');
-    fs.writeFileSync('tmp/data/1/2/3/4.geojson', JSON.stringify({
-      id: 4,
-      properties: {
-        'wof:name': 'name 1',
-        'wof:placetype': 'place type 1',
-        'wof:parent_id': 2,
-        'geom:latitude': 12.121212,
-        'geom:longitude': 21.212121
-      }
-    }));
-
-    // write out second meta and data files
-    fs.writeFileSync('tmp/meta/wof-type2-latest.csv', 'path\n5/6/7/8.geojson\n');
-    fs.writeFileSync('tmp/data/5/6/7/8.geojson', JSON.stringify({
-      id: 8,
-      properties: {
-        'wof:name': 'name 2',
-        'wof:placetype': 'place type 2',
-        'wof:parent_id': 3,
-        'geom:latitude': 13.131313,
-        'geom:longitude': 31.313131
-      }
-    }));
-
-    // write out third meta and data files that are ignored
-    fs.writeFileSync('tmp/meta/wof-type3-latest.csv', 'path\n9/10/11/12.geojson\n');
-    fs.writeFileSync('tmp/data/9/10/11/12.geojson', JSON.stringify({
-      id: 12,
-      properties: {
-        'wof:name': 'name 3',
-        'wof:placetype': 'place type 3',
-        'wof:parent_id': 4,
-        'geom:latitude': 14.141414,
-        'geom:longitude': 41.414141
-      }
-    }));
+    setupTestEnvironment();
 
     var wofRecords = {};
 
@@ -81,13 +35,69 @@ tape('readStream', function(test) {
         lon: 31.313131
       }, 'id 8 should have been loaded');
 
-      // cleanup
-      fs.removeSync('tmp');
-
       t.end();
+
+      cleanupTestEnvironment();
 
     });
 
   });
 
 });
+
+function setupTestEnvironment() {
+  // remove tmp directory if for some reason it's been hanging around from a previous run
+  fs.removeSync('tmp');
+
+  fs.mkdirsSync('tmp/meta');
+
+  // write out first meta and data files
+  fs.writeFileSync('tmp/meta/wof-type1-latest.csv', 'path\n1/2/3/4.geojson\n');
+  fs.mkdirsSync('tmp/data/1/2/3');
+  fs.writeFileSync('tmp/data/1/2/3/4.geojson', JSON.stringify({
+    id: 4,
+    properties: {
+      'wof:name': 'name 1',
+      'wof:placetype': 'place type 1',
+      'wof:parent_id': 2,
+      'geom:latitude': 12.121212,
+      'geom:longitude': 21.212121
+    }
+  }));
+
+  // write out second meta and data files
+  fs.writeFileSync('tmp/meta/wof-type2-latest.csv', 'path\n5/6/7/8.geojson\n');
+  fs.mkdirsSync('tmp/data/5/6/7');
+  fs.writeFileSync('tmp/data/5/6/7/8.geojson', JSON.stringify({
+    id: 8,
+    properties: {
+      'wof:name': 'name 2',
+      'wof:placetype': 'place type 2',
+      'wof:parent_id': 3,
+      'geom:latitude': 13.131313,
+      'geom:longitude': 31.313131
+    }
+  }));
+
+  // write out third meta and data files that are ignored
+  // it will be ignored since 'type3' is not passed as a supported type
+  // this shows that types are supported instead of all files being globbed
+  fs.writeFileSync('tmp/meta/wof-type3-latest.csv', 'path\n9/10/11/12.geojson\n');
+  fs.mkdirsSync('tmp/data/9/10/11');
+  fs.writeFileSync('tmp/data/9/10/11/12.geojson', JSON.stringify({
+    id: 12,
+    properties: {
+      'wof:name': 'name 3',
+      'wof:placetype': 'place type 3',
+      'wof:parent_id': 4,
+      'geom:latitude': 14.141414,
+      'geom:longitude': 41.414141
+    }
+  }));
+
+}
+
+function cleanupTestEnvironment() {
+  fs.removeSync('tmp');
+
+}

--- a/test/readStreamTest.js
+++ b/test/readStreamTest.js
@@ -1,0 +1,110 @@
+var tape = require('tape');
+var event_stream = require('event-stream');
+var fs = require('fs-extra');
+
+var readStream = require('../src/readStream');
+
+/*
+ * Test a stream with the following process:
+ * 1. take input as array
+ * 2. turn the array into a stream
+ * 3. pipe through stream to be tested
+ * 4. pass output of that stream to a callback function
+ * 5. assertions can then be made in that callback
+ *
+ * Callback signature should be something like function callback(error, result)
+ */
+function test_stream(input, testedStream, callback) {
+    var input_stream = event_stream.readArray(input);
+    var destination_stream = event_stream.writeArray(callback);
+
+    input_stream.pipe(testedStream).pipe(destination_stream);
+}
+
+tape('readStream', function(test) {
+  /*
+    this test is not terribly attractive, i'm not happy with it but setup wasn't
+    all that painful. 
+  */
+  test.test('readStream should return from all requested types and populate wofRecords', function(t) {
+    // remove tmp directory if for some reason it's been hanging around from a previous run
+    fs.removeSync('tmp');
+
+    // shell out since creating multiple levels of directories in node is tedious
+    fs.mkdirsSync('tmp/meta');
+    fs.mkdirsSync('tmp/data/1/2/3');
+    fs.mkdirsSync('tmp/data/5/6/7');
+    fs.mkdirsSync('tmp/data/9/10/11');
+
+    // write out first meta and data files
+    fs.writeFileSync('tmp/meta/wof-type1-latest.csv', 'path\n1/2/3/4.geojson\n');
+    fs.writeFileSync('tmp/data/1/2/3/4.geojson', JSON.stringify({
+      id: 4,
+      properties: {
+        'wof:name': 'name 1',
+        'wof:placetype': 'place type 1',
+        'wof:parent_id': 2,
+        'geom:latitude': 12.121212,
+        'geom:longitude': 21.212121
+      }
+    }));
+
+    // write out second meta and data files
+    fs.writeFileSync('tmp/meta/wof-type2-latest.csv', 'path\n5/6/7/8.geojson\n');
+    fs.writeFileSync('tmp/data/5/6/7/8.geojson', JSON.stringify({
+      id: 8,
+      properties: {
+        'wof:name': 'name 2',
+        'wof:placetype': 'place type 2',
+        'wof:parent_id': 3,
+        'geom:latitude': 13.131313,
+        'geom:longitude': 31.313131
+      }
+    }));
+
+    // write out third meta and data files that are ignored
+    fs.writeFileSync('tmp/meta/wof-type3-latest.csv', 'path\n9/10/11/12.geojson\n');
+    fs.writeFileSync('tmp/data/9/10/11/12.geojson', JSON.stringify({
+      id: 12,
+      properties: {
+        'wof:name': 'name 3',
+        'wof:placetype': 'place type 3',
+        'wof:parent_id': 4,
+        'geom:latitude': 14.141414,
+        'geom:longitude': 41.414141
+      }
+    }));
+
+    var wofRecords = {};
+
+    readStream('./tmp/', ['type1', 'type2'], wofRecords, function() {
+      t.equals(Object.keys(wofRecords).length, 2, 'there should be 2 records loaded');
+
+      t.deepEqual(wofRecords[4], {
+        id: 4,
+        name: 'name 1',
+        place_type: 'place type 1',
+        parent_id: 2,
+        lat: 12.121212,
+        lon: 21.212121
+      }, 'id 4 should have been loaded');
+
+      t.deepEqual(wofRecords[8], {
+        id: 8,
+        name: 'name 2',
+        place_type: 'place type 2',
+        parent_id: 3,
+        lat: 13.131313,
+        lon: 31.313131
+      }, 'id 8 should have been loaded');
+
+      // cleanup
+      fs.removeSync('tmp');
+
+      t.end();
+
+    });
+
+  });
+
+});

--- a/test/test.js
+++ b/test/test.js
@@ -1,1 +1,2 @@
 require ('./readStreamComponentsTest.js');
+require ('./readStreamTest.js');


### PR DESCRIPTION
readStreamTest.js test is a bit tedious but setup wasn't all that bad.  Alternatively the strategy would be to inject either an array of streams or an options object containing all the requested streams.  I'd prefer the former but I couldn't figure out how to iterate a list and chain together the pipes.  