### PR TITLE
Filter out blank name fields

### DIFF
--- a/src/components/filterOutNamelessRecords.js
+++ b/src/components/filterOutNamelessRecords.js
@@ -1,0 +1,8 @@
+var filter = require('through2-filter');
+var _ = require('lodash');
+
+module.exports.create = function() {
+  return filter.obj(function(wofRecord) {
+    return !_.isEmpty(_.trim(wofRecord.name));
+  });
+};

--- a/src/readStream.js
+++ b/src/readStream.js
@@ -4,6 +4,7 @@ var batch = require('batchflow');
 var sink = require('through2-sink');
 
 var readStreamComponents = require('./readStreamComponents');
+var filterOutNamelessRecords = require('./components/filterOutNamelessRecords');
 
 /*
   This function finds all the `latest` files in `meta/`, CSV parses them,
@@ -18,6 +19,7 @@ function readData(directory, types, wofRecords, callback) {
     var json_parse_stream = readStreamComponents.json_parse_stream(directory + 'data/');
     var filter_incomplete_files_stream = readStreamComponents.filter_incomplete_files_stream();
     var map_fields_stream = readStreamComponents.map_fields_stream();
+    var filter_out_nameless_records = filterOutNamelessRecords.create();
 
     fs.createReadStream(directory + 'meta/wof-' + type + '-latest.csv')
     .pipe(csv_parser)
@@ -27,6 +29,7 @@ function readData(directory, types, wofRecords, callback) {
     .pipe(json_parse_stream)
     .pipe(filter_incomplete_files_stream)
     .pipe(map_fields_stream)
+    .pipe(filter_out_nameless_records)
     .pipe(sink.obj(function(wofRecord) {
       wofRecords[wofRecord.id] = wofRecord;
     }))

--- a/test/components/filterOutNamelessRecordsTest.js
+++ b/test/components/filterOutNamelessRecordsTest.js
@@ -1,0 +1,50 @@
+var tape = require('tape');
+var event_stream = require('event-stream');
+
+var filterOutNamelessRecords = require('../../src/components/filterOutNamelessRecords');
+
+function test_stream(input, testedStream, callback) {
+    var input_stream = event_stream.readArray(input);
+    var destination_stream = event_stream.writeArray(callback);
+
+    input_stream.pipe(testedStream).pipe(destination_stream);
+}
+
+tape('filterOutNamelessRecords', function(test) {
+  test.test('undefined/blank names should return false', function(t) {
+    var input = [
+      { name: undefined },
+      { name: '' },
+      { name: ' \t '}
+    ];
+    var expected = [];
+
+    var filter = filterOutNamelessRecords.create();
+
+    test_stream(input, filter, function(err, actual) {
+      t.deepEqual(actual, expected, 'should have returned true');
+      t.end();
+    });
+
+  });
+
+  test.test('non-blank names should return true', function(t) {
+    var input = [
+      { name: 'name' }
+    ];
+    var expected = [
+      { name: 'name' }
+    ];
+
+    var filter = filterOutNamelessRecords.create();
+
+    test_stream(input, filter, function(err, actual) {
+      t.deepEqual(actual, expected, 'should have returned true');
+      t.end();
+    });
+
+  });
+
+
+
+});

--- a/test/test.js
+++ b/test/test.js
@@ -4,3 +4,4 @@ require ('./importStreamTest.js');
 require ('./peliasDocGeneratorsTest.js');
 require ('./wofRecordStreamTest.js');
 require ('./hierarchyFinderTest.js');
+require ('./components/filterOutNamelessRecordsTest.js');


### PR DESCRIPTION
Somehow the model was allowing nameless WOF records through.  This eliminates them.  For good.  Summarily.  

Fixed #52 