### PR TITLE
Add `zs:pop10` value for population candidate value

### DIFF
--- a/src/readStreamComponents.js
+++ b/src/readStreamComponents.js
@@ -81,6 +81,17 @@ function isUsCounty(base_record, qs_a2_alt) {
           !_.isUndefined(qs_a2_alt);
 }
 
+// this function favors gn:population when available, falling back to zs:pop10
+//  when available and > 0
+function getPopulation(properties) {
+  if (properties['gn:population']) {
+    return properties['gn:population'];
+  } else if (properties['zs:pop10']) {
+    return properties['zs:pop10'];
+  }
+
+}
+
 /*
   This function extracts the fields from the json_object that we're interested
   in for creating Pelias Document objects.  If there is no hierarchy then a
@@ -99,7 +110,7 @@ var map_fields_stream = function map_fields_stream() {
       lon: json_object.properties['geom:longitude'],
       bounding_box: json_object.properties['geom:bbox'],
       iso2: json_object.properties['iso:country'],
-      population: json_object.properties['gn:population'],
+      population: getPopulation(json_object.properties),
       popularity: json_object.properties['misc:photo_sum']
     };
 

--- a/test/readStreamComponentsTest.js
+++ b/test/readStreamComponentsTest.js
@@ -220,7 +220,134 @@ tape('readStreamComponents', function(test) {
 
   });
 
-  test.test('gn:population not found should not include population', function(t) {
+  test.test('gn:population should be favored over zs:pop10 when both are available', function(t) {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'name 1',
+          'wof:placetype': 'place type 1',
+          'wof:parent_id': 'parent id 1',
+          'geom:latitude': 12.121212,
+          'geom:longitude': 21.212121,
+          'geom:bbox': '-13.691314,49.909613,1.771169,60.847886',
+          'iso:country': 'YZ',
+          'wof:abbreviation': 'XY',
+          'gn:population': 98765,
+          'zs:pop10': 87654,
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'name 1',
+        place_type: 'place type 1',
+        parent_id: 'parent id 1',
+        lat: 12.121212,
+        lon: 21.212121,
+        iso2: 'YZ',
+        population: 98765,
+        popularity: undefined,
+        abbreviation: 'XY',
+        bounding_box: '-13.691314,49.909613,1.771169,60.847886',
+      }
+    ];
+    var map_fields_stream = readStreamComponents.map_fields_stream();
+
+    test_stream(input, map_fields_stream, function(err, actual) {
+      t.deepEqual(actual, expected, 'population should not be set');
+      t.end();
+    });
+
+  });
+
+  test.test('non-0 zs:pop10 should be used for population when gn:population is not found', function(t) {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'name 1',
+          'wof:placetype': 'place type 1',
+          'wof:parent_id': 'parent id 1',
+          'geom:latitude': 12.121212,
+          'geom:longitude': 21.212121,
+          'geom:bbox': '-13.691314,49.909613,1.771169,60.847886',
+          'iso:country': 'YZ',
+          'wof:abbreviation': 'XY',
+          'zs:pop10': 98765,
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'name 1',
+        place_type: 'place type 1',
+        parent_id: 'parent id 1',
+        lat: 12.121212,
+        lon: 21.212121,
+        iso2: 'YZ',
+        population: 98765,
+        popularity: undefined,
+        abbreviation: 'XY',
+        bounding_box: '-13.691314,49.909613,1.771169,60.847886',
+      }
+    ];
+    var map_fields_stream = readStreamComponents.map_fields_stream();
+
+    test_stream(input, map_fields_stream, function(err, actual) {
+      t.deepEqual(actual, expected, 'population should not be set');
+      t.end();
+    });
+
+  });
+
+  test.test('0 value zs:pop10 and gn:popuation not found should not set population', function(t) {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'name 1',
+          'wof:placetype': 'place type 1',
+          'wof:parent_id': 'parent id 1',
+          'geom:latitude': 12.121212,
+          'geom:longitude': 21.212121,
+          'geom:bbox': '-13.691314,49.909613,1.771169,60.847886',
+          'iso:country': 'YZ',
+          'wof:abbreviation': 'XY',
+          'zs:pop10': 0,
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'name 1',
+        place_type: 'place type 1',
+        parent_id: 'parent id 1',
+        lat: 12.121212,
+        lon: 21.212121,
+        iso2: 'YZ',
+        population: undefined,
+        popularity: undefined,
+        abbreviation: 'XY',
+        bounding_box: '-13.691314,49.909613,1.771169,60.847886',
+      }
+    ];
+    var map_fields_stream = readStreamComponents.map_fields_stream();
+
+    test_stream(input, map_fields_stream, function(err, actual) {
+      t.deepEqual(actual, expected, 'population should not be set');
+      t.end();
+    });
+
+  });
+
+  test.test('neither gn:population nor zs:pop10 not found should not include population', function(t) {
     var input = [
       {
         id: 12345,


### PR DESCRIPTION
NYC (and other neighborhoods) don't appear to have `gn:population` values, so inputs like `Chelsea` are being punished in scoring for no other reason than lack of value (even the default `1` value isn't helping).  This fix uses the `zs:pop10` value for population when non-zero and `gn:population` is not available.  It's likely that `gn:population` and `zs:pop10` presence are mutually exclusive.

Fixed #59
Fixed pelias/pelias#300