### PR TITLE
added helper methods and check for `mz:is_current` === 0 (inactive)

### DIFF
--- a/src/components/isActiveRecord.js
+++ b/src/components/isActiveRecord.js
@@ -1,8 +1,20 @@
 var filter = require('through2-filter');
 var _ = require('lodash');
 
-module.exports.create = function create() {
+function isDeprecated(wofData) {
+  return !_.isEmpty(_.trim(wofData.properties['edtf:deprecated']));
+}
+
+function isSuperseded(wofData) {
+  return !_.isEmpty(_.trim(wofData.properties['edtf:superseded']));
+}
+
+function isCurrent(wofData) {
+  return wofData.properties['mz:is_current'] !== 0;
+}
+
+module.exports.create = function() {
   return filter.obj(function(wofData) {
-    return _.isEmpty(_.trim(wofData.properties['edtf:deprecated']));
+    return !isDeprecated(wofData) && !isSuperseded(wofData) && isCurrent(wofData);
   });
 };

--- a/test/components/isActiveRecordTest.js
+++ b/test/components/isActiveRecordTest.js
@@ -11,48 +11,16 @@ function test_stream(input, testedStream, callback) {
 }
 
 tape('isActiveRecord', function(test) {
-  test.test('undefined/blank values should return false', function(t) {
+  test.test('undefined/blank edtf:deprecated values should return true', function(t) {
     var input = [
-      {
-        properties: {
-          'edtf:deprecated': undefined,
-        }
-      },
-      {
-        properties: {
-          'edtf:deprecated': '',
-        }
-      },
-      {
-        properties: {
-          'edtf:deprecated': ' \t ',
-        }
-      },
-      {
-        properties: {
-        }
-      }
+      { properties: { 'edtf:deprecated': undefined } },
+      { properties: { 'edtf:deprecated': '' } },
+      { properties: { 'edtf:deprecated': ' \t ' } }
     ];
     var expected = [
-      {
-        properties: {
-          'edtf:deprecated': undefined,
-        }
-      },
-      {
-        properties: {
-          'edtf:deprecated': '',
-        }
-      },
-      {
-        properties: {
-          'edtf:deprecated': ' \t ',
-        }
-      },
-      {
-        properties: {
-        }
-      }
+      { properties: { 'edtf:deprecated': undefined } },
+      { properties: { 'edtf:deprecated': '' } },
+      { properties: { 'edtf:deprecated': ' \t ' } }
     ];
 
     test_stream(input, isActiveRecord.create(), function(err, actual) {
@@ -62,13 +30,43 @@ tape('isActiveRecord', function(test) {
 
   });
 
-  test.test('non-blank values should return true', function(t) {
+  test.test('undefined/blank edtf:superseded values should return true', function(t) {
     var input = [
-      {
-        properties: {
-          'edtf:deprecated': 'some value',
-        }
-      }
+      { properties: { 'edtf:superseded': undefined } },
+      { properties: { 'edtf:superseded': '' } },
+      { properties: { 'edtf:superseded': ' \t ' } }
+    ];
+    var expected = [
+      { properties: { 'edtf:superseded': undefined } },
+      { properties: { 'edtf:superseded': '' } },
+      { properties: { 'edtf:superseded': ' \t ' } }
+    ];
+
+    test_stream(input, isActiveRecord.create(), function(err, actual) {
+      t.deepEqual(actual, expected, 'should have returned true');
+      t.end();
+    });
+
+  });
+
+  test.test('properties without edtf:superseded or edtf:deprecated or mz:is_current should return true', function(t) {
+    var input = [
+      { properties: { } }
+    ];
+    var expected = [
+      { properties: { } }
+    ];
+
+    test_stream(input, isActiveRecord.create(), function(err, actual) {
+      t.deepEqual(actual, expected, 'should have returned true');
+      t.end();
+    });
+
+  });
+
+  test.test('non-blank edtf:deprecated values should return false', function(t) {
+    var input = [
+      { properties: { 'edtf:deprecated': 'some value' } }
     ];
     var expected = [];
 
@@ -79,6 +77,30 @@ tape('isActiveRecord', function(test) {
 
   });
 
+  test.test('non-blank edtf:superseded values should return false', function(t) {
+    var input = [
+      { properties: { 'edtf:superseded': 'some value' } }
+    ];
+    var expected = [];
 
+    test_stream(input, isActiveRecord.create(), function(err, actual) {
+      t.deepEqual(actual, expected, 'should have returned false');
+      t.end();
+    });
+
+  });
+
+  test.test('mz:is_current 0 value should return false', function(t) {
+    var input = [
+      { properties: { 'mz:is_current': 0 } }
+    ];
+    var expected = [];
+
+    test_stream(input, isActiveRecord.create(), function(err, actual) {
+      t.deepEqual(actual, expected, 'should have returned false');
+      t.end();
+    });
+
+  });
 
 });


### PR DESCRIPTION
Support edtf:superseded and mz:is_current checks for active records. Fixed #70