### PR TITLE
Add multiple hierarchy support

### DIFF
--- a/src/components/extractFields.js
+++ b/src/components/extractFields.js
@@ -62,7 +62,7 @@ function getName(properties) {
 */
 module.exports.create = function map_fields_stream() {
   return through2.obj(function(json_object, enc, callback) {
-    var base_record = {
+    var record = {
       id: json_object.id,
       name: getName(json_object.properties),
       abbreviation: json_object.properties['wof:abbreviation'],
@@ -73,29 +73,16 @@ module.exports.create = function map_fields_stream() {
       bounding_box: getBoundingBox(json_object.properties),
       iso2: json_object.properties['iso:country'],
       population: getPopulation(json_object.properties),
-      popularity: json_object.properties['misc:photo_sum']
+      popularity: json_object.properties['misc:photo_sum'],
+      hierarchies: _.get(json_object, 'properties.wof:hierarchy', [])
     };
 
     // use the QS altname if US county and available
-    if (isUsCounty(base_record, json_object.properties['qs:a2_alt'])) {
-      base_record.name = json_object.properties['qs:a2_alt'];
+    if (isUsCounty(record, json_object.properties['qs:a2_alt'])) {
+      record.name = json_object.properties['qs:a2_alt'];
     }
 
-    // if there's no hierarchy then just add the base record
-    if (_.isUndefined(json_object.properties['wof:hierarchy'])) {
-      this.push(base_record);
-
-    } else {
-      // otherwise, clone the base record for each hierarchy in the list and push
-      json_object.properties['wof:hierarchy'].forEach(function(hierarchy) {
-        var clone = _.clone(base_record, true);
-        clone.hierarchy = hierarchy;
-        this.push(clone);
-      }, this);
-
-    }
-
-    return callback();
+    return callback(null, record);
 
   });
 

--- a/src/hierarchyFinder.js
+++ b/src/hierarchyFinder.js
@@ -27,7 +27,7 @@ module.exports.parent_id_walker = function(wofRecords) {
       parent_id = parent.parent_id;
     }
 
-    return parents.filter(hasName);
+    return [parents.filter(hasName)];
 
   };
 
@@ -53,10 +53,22 @@ module.exports.parent_id_walker = function(wofRecords) {
   lastly, filter out any hierarchy elements that are undefined or w/o a name
 
 */
+function resolveHierarchy(wofRecords, hierarchy) {
+  return Object.keys(hierarchy).map(function(key) {
+    return wofRecords[hierarchy[key]];
+  }).filter(isDefined).filter(hasName);
+}
+
+/*
+ This function returns all the resolved hierarchies for a wofRecord.  Each
+ wofRecord can have multiple hierarchies, so resolve them by looking up the
+ referenced wofRecord in the big collection of wofRecords.
+*/
 module.exports.hierarchies_walker = function(wofRecords) {
   return function(wofRecord) {
-    return Object.keys(wofRecord.hierarchy).map(function(key) {
-      return wofRecords[wofRecord.hierarchy[key]];
-    }).filter(isDefined).filter(hasName);
+    return wofRecord.hierarchies.reduce(function(resolvedHierarchies, hierarchy) {
+      resolvedHierarchies.push(resolveHierarchy(wofRecords, hierarchy));
+      return resolvedHierarchies;
+    }, []);
   };
 };

--- a/src/peliasDocGenerators.js
+++ b/src/peliasDocGenerators.js
@@ -1,4 +1,4 @@
-var map_stream = require('through2-map');
+var through2 = require('through2');
 var _ = require('lodash');
 var iso3166 = require('iso3166-1');
 
@@ -6,83 +6,111 @@ var Document = require('pelias-model').Document;
 
 module.exports = {};
 
-module.exports.create = function(hierarchy_finder) {
-  return map_stream.obj(function(record) {
-    var wofDoc = new Document( 'whosonfirst', record.place_type, record.id );
-
-    if (record.name) {
-      wofDoc.setName('default', record.name);
-    }
-    wofDoc.setCentroid({ lat: record.lat, lon: record.lon });
-
-    // only set population if available
-    if (record.population) {
-      wofDoc.setPopulation(record.population);
-    }
-
-    // only set popularity if available
-    if (record.popularity) {
-      wofDoc.setPopularity(record.popularity);
-    }
-
-    // WOF bbox is defined as:
-    // lowerLeft.lon, lowerLeft.lat, upperRight.lon, upperRight.lat
-    // so convert to what ES understands
-    if (!_.isUndefined(record.bounding_box)) {
-      var parsedBoundingBox = record.bounding_box.split(',').map(parseFloat);
-      var marshaledBoundingBoxBox = {
-        upperLeft: {
-          lat: parsedBoundingBox[3],
-          lon: parsedBoundingBox[0]
-        },
-        lowerRight: {
-          lat: parsedBoundingBox[1],
-          lon: parsedBoundingBox[2]
-        }
-
-      };
-      wofDoc.setBoundingBox(marshaledBoundingBoxBox);
-    }
-
-    // iterate the hierarchy, assigning fields
-    hierarchy_finder(record).forEach(function(hierarchy_element) {
-      switch (hierarchy_element.place_type) {
-        case 'neighbourhood':
-        case 'locality':
-        case 'borough':
-        case 'localadmin':
-        case 'county':
-        case 'macrocounty':
-        case 'macroregion':
-          // the above place_types don't have abbrevations (yet)
-          wofDoc.addParent(hierarchy_element.place_type, hierarchy_element.name, hierarchy_element.id.toString());
-          break;
-        case 'region':
-        case 'dependency':
-          if (hierarchy_element.hasOwnProperty('abbreviation')) {
-            wofDoc.addParent(hierarchy_element.place_type, hierarchy_element.name, hierarchy_element.id.toString(), hierarchy_element.abbreviation);
-          } else {
-            wofDoc.addParent(hierarchy_element.place_type, hierarchy_element.name, hierarchy_element.id.toString());
-          }
-          break;
-        case 'country':
-          // this is placetype=country, so lookup and set the iso3 from iso2
-          if (iso3166.is2(hierarchy_element.iso2)) {
-            var iso3 = iso3166.to3(hierarchy_element.iso2);
-
-            wofDoc.setAlpha3(iso3);
-            wofDoc.addParent('country', hierarchy_element.name, hierarchy_element.id.toString(), iso3);
-
-          } else {
-            wofDoc.addParent('country', hierarchy_element.name, hierarchy_element.id.toString());
-
-          }
-
-          break;
+function assignField(hierarchyElement, wofDoc) {
+  switch (hierarchyElement.place_type) {
+    case 'neighbourhood':
+    case 'locality':
+    case 'borough':
+    case 'localadmin':
+    case 'county':
+    case 'macrocounty':
+    case 'macroregion':
+      // the above place_types don't have abbrevations (yet)
+      wofDoc.addParent(hierarchyElement.place_type, hierarchyElement.name, hierarchyElement.id.toString());
+      break;
+    case 'region':
+    case 'dependency':
+      if (hierarchyElement.hasOwnProperty('abbreviation')) {
+        wofDoc.addParent(hierarchyElement.place_type, hierarchyElement.name, hierarchyElement.id.toString(), hierarchyElement.abbreviation);
+      } else {
+        wofDoc.addParent(hierarchyElement.place_type, hierarchyElement.name, hierarchyElement.id.toString());
       }
+      break;
+    case 'country':
+      // this is placetype=country, so lookup and set the iso3 from iso2
+      if (iso3166.is2(hierarchyElement.iso2)) {
+        var iso3 = iso3166.to3(hierarchyElement.iso2);
+
+        wofDoc.setAlpha3(iso3);
+        wofDoc.addParent('country', hierarchyElement.name, hierarchyElement.id.toString(), iso3);
+
+      } else {
+        wofDoc.addParent('country', hierarchyElement.name, hierarchyElement.id.toString());
+
+      }
+
+      break;
+  }
+
+}
+
+// method that extracts the logic for Document creation.  `hierarchy` is optional
+function setupDocument(record, hierarchy) {
+  var wofDoc = new Document( 'whosonfirst', record.place_type, record.id );
+
+  if (record.name) {
+    wofDoc.setName('default', record.name);
+  }
+  wofDoc.setCentroid({ lat: record.lat, lon: record.lon });
+
+  // only set population if available
+  if (record.population) {
+    wofDoc.setPopulation(record.population);
+  }
+
+  // only set popularity if available
+  if (record.popularity) {
+    wofDoc.setPopularity(record.popularity);
+  }
+
+  // WOF bbox is defined as:
+  // lowerLeft.lon, lowerLeft.lat, upperRight.lon, upperRight.lat
+  // so convert to what ES understands
+  if (!_.isUndefined(record.bounding_box)) {
+    var parsedBoundingBox = record.bounding_box.split(',').map(parseFloat);
+    var marshaledBoundingBoxBox = {
+      upperLeft: {
+        lat: parsedBoundingBox[3],
+        lon: parsedBoundingBox[0]
+      },
+      lowerRight: {
+        lat: parsedBoundingBox[1],
+        lon: parsedBoundingBox[2]
+      }
+
+    };
+    wofDoc.setBoundingBox(marshaledBoundingBoxBox);
+  }
+
+  // a `hierarchy` is composed of potentially multiple WOF records, so iterate
+  // and assign fields
+  if (!_.isUndefined(hierarchy)) {
+    hierarchy.forEach(function(hierarchyElement) {
+      assignField(hierarchyElement, wofDoc);
     });
 
-    return wofDoc;
+  }
+
+  return wofDoc;
+
+}
+
+module.exports.create = function(hierarchy_finder) {
+  return through2.obj(function(record, enc, next) {
+    // if there are no hierarchies, then just return the doc as-is
+    var hierarchies = hierarchy_finder(record);
+
+    if (hierarchies && hierarchies.length > 0) {
+      hierarchies.forEach(function(hierarchy) {
+        this.push(setupDocument(record, hierarchy));
+      }, this);
+
+    } else {
+      this.push(setupDocument(record));
+
+    }
+
+    next();
 
   });
 

--- a/test/components/extractFieldsTest.js
+++ b/test/components/extractFieldsTest.js
@@ -115,7 +115,7 @@ tape('readStreamComponents', function(test) {
           'iso:country': 'YZ',
           'wof:abbreviation': 'XY',
           'gn:population': 98765,
-          'zs:pop10': 87654,
+          'zs:pop10': 87654
         }
       }
     ];
@@ -157,7 +157,7 @@ tape('readStreamComponents', function(test) {
           'geom:bbox': '-13.691314,49.909613,1.771169,60.847886',
           'iso:country': 'YZ',
           'wof:abbreviation': 'XY',
-          'zs:pop10': 98765,
+          'zs:pop10': 98765
         }
       }
     ];
@@ -199,7 +199,7 @@ tape('readStreamComponents', function(test) {
           'geom:bbox': '-13.691314,49.909613,1.771169,60.847886',
           'iso:country': 'YZ',
           'wof:abbreviation': 'XY',
-          'qs:pop': 98765,
+          'qs:pop': 98765
         }
       }
     ];
@@ -217,6 +217,7 @@ tape('readStreamComponents', function(test) {
         popularity: undefined,
         abbreviation: 'XY',
         bounding_box: '-13.691314,49.909613,1.771169,60.847886',
+        hierarchies: []
       }
     ];
 
@@ -240,7 +241,7 @@ tape('readStreamComponents', function(test) {
           'geom:bbox': '-13.691314,49.909613,1.771169,60.847886',
           'iso:country': 'YZ',
           'wof:abbreviation': 'XY',
-          'mz:population': 98765,
+          'mz:population': 98765
         }
       }
     ];
@@ -258,6 +259,7 @@ tape('readStreamComponents', function(test) {
         popularity: undefined,
         abbreviation: 'XY',
         bounding_box: '-13.691314,49.909613,1.771169,60.847886',
+        hierarchies: []
       }
     ];
 
@@ -281,7 +283,7 @@ tape('readStreamComponents', function(test) {
           'geom:bbox': '-13.691314,49.909613,1.771169,60.847886',
           'iso:country': 'YZ',
           'wof:abbreviation': 'XY',
-          'zs:pop10': 0,
+          'zs:pop10': 0
         }
       }
     ];
@@ -541,7 +543,8 @@ tape('readStreamComponents', function(test) {
         population: undefined,
         popularity: undefined,
         bounding_box: undefined,
-        abbreviation: undefined
+        abbreviation: undefined,
+        hierarchies: []
       }
     ];
 
@@ -580,7 +583,8 @@ tape('readStreamComponents', function(test) {
         population: undefined,
         popularity: undefined,
         bounding_box: '-14.691314,50.909613,2.771169,61.847886',
-        abbreviation: undefined
+        abbreviation: undefined,
+        hierarchies: []
       }
     ];
 
@@ -619,7 +623,8 @@ tape('readStreamComponents', function(test) {
         population: undefined,
         popularity: undefined,
         bounding_box: '',
-        abbreviation: undefined
+        abbreviation: undefined,
+        hierarchies: []
       }
     ];
 
@@ -657,7 +662,8 @@ tape('readStreamComponents', function(test) {
         population: undefined,
         popularity: undefined,
         bounding_box: '',
-        abbreviation: undefined
+        abbreviation: undefined,
+        hierarchies: []
       }
     ];
 

--- a/test/components/extractFieldsTest.js
+++ b/test/components/extractFieldsTest.js
@@ -69,25 +69,14 @@ tape('readStreamComponents', function(test) {
         popularity: 87654,
         abbreviation: 'XY',
         bounding_box: '-13.691314,49.909613,1.771169,60.847886',
-        hierarchy: {
-          'parent_id': 12345
-        }
-      },
-      {
-        id: 12345,
-        name: 'name 1',
-        place_type: 'place type 1',
-        parent_id: 'parent id 1',
-        lat: 12.121212,
-        lon: 21.212121,
-        iso2: 'YZ',
-        population: 98765,
-        popularity: 87654,
-        abbreviation: 'XY',
-        bounding_box: '-13.691314,49.909613,1.771169,60.847886',
-        hierarchy: {
-          'parent_id': 23456
-        }
+        hierarchies: [
+          {
+            'parent_id': 12345
+          },
+          {
+            'parent_id': 23456
+          }
+        ]
       },
       {
         id: 23456,
@@ -100,7 +89,8 @@ tape('readStreamComponents', function(test) {
         population: undefined,
         popularity: undefined,
         abbreviation: undefined,
-        bounding_box: undefined
+        bounding_box: undefined,
+        hierarchies: []
       }
     ];
 
@@ -143,6 +133,7 @@ tape('readStreamComponents', function(test) {
         popularity: undefined,
         abbreviation: 'XY',
         bounding_box: '-13.691314,49.909613,1.771169,60.847886',
+        hierarchies: []
       }
     ];
 
@@ -184,6 +175,7 @@ tape('readStreamComponents', function(test) {
         popularity: undefined,
         abbreviation: 'XY',
         bounding_box: '-13.691314,49.909613,1.771169,60.847886',
+        hierarchies: []
       }
     ];
 
@@ -307,6 +299,7 @@ tape('readStreamComponents', function(test) {
         popularity: undefined,
         abbreviation: 'XY',
         bounding_box: '-13.691314,49.909613,1.771169,60.847886',
+        hierarchies: []
       }
     ];
 
@@ -347,6 +340,7 @@ tape('readStreamComponents', function(test) {
         popularity: undefined,
         abbreviation: 'XY',
         bounding_box: '-13.691314,49.909613,1.771169,60.847886',
+        hierarchies: []
       }
     ];
 
@@ -387,6 +381,7 @@ tape('readStreamComponents', function(test) {
         popularity: undefined,
         abbreviation: 'XY',
         bounding_box: '-13.691314,49.909613,1.771169,60.847886',
+        hierarchies: []
       }
     ];
 
@@ -425,7 +420,8 @@ tape('readStreamComponents', function(test) {
         population: undefined,
         popularity: undefined,
         bounding_box: undefined,
-        abbreviation: undefined
+        abbreviation: undefined,
+        hierarchies: []
       }
     ];
 
@@ -463,7 +459,8 @@ tape('readStreamComponents', function(test) {
         population: undefined,
         popularity: undefined,
         bounding_box: undefined,
-        abbreviation: undefined
+        abbreviation: undefined,
+        hierarchies: []
       }
     ];
 
@@ -502,7 +499,8 @@ tape('readStreamComponents', function(test) {
         population: undefined,
         popularity: undefined,
         bounding_box: undefined,
-        abbreviation: undefined
+        abbreviation: undefined,
+        hierarchies: []
       }
     ];
 

--- a/test/hierarchyFinderTest.js
+++ b/test/hierarchyFinderTest.js
@@ -30,12 +30,12 @@ tape('parent_id_walker tests', function(test) {
 
     var hierarchies = parent_id_walker(wofRecords['4']);
 
-    t.deepEqual(hierarchies, [
+    t.deepEqual(hierarchies, [[
       wofRecords['4'],
       wofRecords['3'],
       wofRecords['2'],
       wofRecords['1']
-    ]);
+    ]]);
     t.end();
 
   });
@@ -67,10 +67,10 @@ tape('parent_id_walker tests', function(test) {
 
     var hierarchies = parent_id_walker(wofRecords['4']);
 
-    t.deepEqual(hierarchies, [
+    t.deepEqual(hierarchies, [[
       wofRecords['4'],
       wofRecords['1']
-    ]);
+    ]]);
     t.end();
 
   });
@@ -92,12 +92,18 @@ tape('hierarchies_walker tests', function(test) {
       },
       4: {
         name: 'name 4',
-        hierarchy: { // keys don't matter
-          'first arbitrary level': 4,
-          'second arbitrary level': 3,
-          'third arbitrary level': 2,
-          'fourth arbitrary level': 1
-        }
+        hierarchies: [
+          { // keys don't matter
+            'first arbitrary level': 4,
+            'second arbitrary level': 3,
+            'third arbitrary level': 2,
+            'fourth arbitrary level': 1
+          },
+          {
+            'fifth arbitrary level': 4,
+            'sixth arbitrary level': 2
+          }
+        ]
       }
     };
 
@@ -107,10 +113,16 @@ tape('hierarchies_walker tests', function(test) {
     var hierarchies = hierarchies_walker(wofRecords['4']);
 
     t.deepEqual(hierarchies, [
-      wofRecords['4'],
-      wofRecords['3'],
-      wofRecords['2'],
-      wofRecords['1']
+      [
+        wofRecords['4'],
+        wofRecords['3'],
+        wofRecords['2'],
+        wofRecords['1']
+      ],
+      [
+        wofRecords['4'],
+        wofRecords['2']
+      ]
     ]);
     t.end();
 
@@ -130,12 +142,14 @@ tape('hierarchies_walker tests', function(test) {
       },
       4: {
         name: 'name 4',
-        hierarchy: { // keys don't matter
-          'first arbitrary level': 4,
-          'second arbitrary level': 3, // no name, will be excluded
-          'third arbitrary level': 2,
-          'fourth arbitrary level': 1
-        }
+        hierarchies: [
+          { // keys don't matter
+            'first arbitrary level': 4,
+            'second arbitrary level': 3, // no name, will be excluded
+            'third arbitrary level': 2,
+            'fourth arbitrary level': 1
+          }
+        ]
       }
     };
 
@@ -144,11 +158,11 @@ tape('hierarchies_walker tests', function(test) {
 
     var hierarchies = hierarchies_walker(wofRecords['4']);
 
-    t.deepEqual(hierarchies, [
+    t.deepEqual(hierarchies, [[
       wofRecords['4'],
       wofRecords['2'],
       wofRecords['1']
-    ]);
+    ]]);
     t.end();
 
   });
@@ -164,12 +178,12 @@ tape('hierarchies_walker tests', function(test) {
       },
       4: {
         name: 'name 4',
-        hierarchy: { // keys don't matter
+        hierarchies: [{ // keys don't matter
           'first arbitrary level': 4,
           'second arbitrary level': 3,
           'third arbitrary level': 2, // this will be undefined
           'fourth arbitrary level': 1
-        }
+        }]
       }
     };
 
@@ -179,9 +193,11 @@ tape('hierarchies_walker tests', function(test) {
     var hierarchy = hierarchies_walker(wofRecords['4']);
 
     t.deepEqual(hierarchy, [
-      wofRecords['4'],
-      wofRecords['3'],
-      wofRecords['1']
+      [
+        wofRecords['4'],
+        wofRecords['3'],
+        wofRecords['1']
+      ]
     ]);
     t.end();
 

--- a/test/peliasDocGeneratorsTest.js
+++ b/test/peliasDocGeneratorsTest.js
@@ -41,11 +41,12 @@ tape('create', function(test) {
 
       var hierarchies_finder = function() {
         return [
-          wofRecords['1']
+          [
+            wofRecords['1']
+          ]
         ];
       };
 
-      // seed the parent_id_walker with wofRecords
       var docGenerator = peliasDocGenerators.create(hierarchies_finder);
 
       test_stream(input, docGenerator, function(err, actual) {
@@ -58,7 +59,7 @@ tape('create', function(test) {
 
   });
 
-  test.test('place_types that allow abbreviations should honor them when available', function(t) {
+  test.test('region and dependency (that allow abbreviations) should honor them when available', function(t) {
     ['region', 'dependency'].forEach(function(place_type) {
       var wofRecords = {
         1: {
@@ -87,11 +88,12 @@ tape('create', function(test) {
 
       var hierarchies_finder = function() {
         return [
-          wofRecords['1']
+          [
+            wofRecords['1']
+          ]
         ];
       };
 
-      // seed the parent_id_walker with wofRecords
       var docGenerator = peliasDocGenerators.create(hierarchies_finder);
 
       test_stream(input, docGenerator, function(err, actual) {
@@ -132,7 +134,6 @@ tape('create', function(test) {
       return [];
     };
 
-    // seed the parent_id_walker with wofRecords
     var docGenerator = peliasDocGenerators.create(hierarchies_finder);
 
     test_stream(input, docGenerator, function(err, actual) {
@@ -144,32 +145,31 @@ tape('create', function(test) {
 
   test.test('wofRecord without bounding_box should have undefined bounding box in output', function(t) {
     var wofRecords = {
-      1: {
-        id: 1,
-        name: 'name 1',
-        lat: 12.121212,
-        lon: 21.212121,
-        parent_id: undefined,
-        place_type: 'continent'
-      }
+     1: {
+       id: 1,
+       name: 'name 1',
+       lat: 12.121212,
+       lon: 21.212121,
+       parent_id: undefined,
+       place_type: 'continent'
+     }
     };
 
     var input = [
-      wofRecords['1']
+     wofRecords['1']
     ];
 
     var expected = [
-      new Document( 'whosonfirst', 'continent', '1' )
-        .setName('default', 'name 1')
-        .setCentroid({ lat: 12.121212, lon: 21.212121 })
+     new Document( 'whosonfirst', 'continent', '1' )
+       .setName('default', 'name 1')
+       .setCentroid({ lat: 12.121212, lon: 21.212121 })
     ];
 
     // don't care about hierarchies in this test
     var hierarchies_finder = function() {
-      return [];
+     return [];
     };
 
-    // seed the parent_id_walker with wofRecords
     var docGenerator = peliasDocGenerators.create(hierarchies_finder);
 
     test_stream(input, docGenerator, function(err, actual) {
@@ -207,7 +207,6 @@ tape('create', function(test) {
       return [];
     };
 
-    // seed the parent_id_walker with wofRecords
     var docGenerator = peliasDocGenerators.create(hierarchies_finder);
 
     test_stream(input, docGenerator, function(err, actual) {
@@ -243,11 +242,12 @@ tape('create', function(test) {
 
     var hierarchies_finder = function() {
       return [
-        wofRecords['1']
+        [
+          wofRecords['1']
+        ]
       ];
     };
 
-    // seed the parent_id_walker with wofRecords
     var docGenerator = peliasDocGenerators.create(hierarchies_finder);
 
     test_stream(input, docGenerator, function(err, actual) {
@@ -284,11 +284,12 @@ tape('create', function(test) {
 
     var hierarchies_finder = function() {
       return [
-        wofRecords['1']
+        [
+          wofRecords['1']
+        ]
       ];
     };
 
-    // seed the parent_id_walker with wofRecords
     var docGenerator = peliasDocGenerators.create(hierarchies_finder);
 
     test_stream(input, docGenerator, function(err, actual) {
@@ -327,11 +328,12 @@ tape('create', function(test) {
 
     var hierarchies_finder = function() {
       return [
-        wofRecords['1']
+        [
+          wofRecords['1']
+        ]
       ];
     };
 
-    // seed the parent_id_walker with wofRecords
     var docGenerator = peliasDocGenerators.create(hierarchies_finder);
 
     test_stream(input, docGenerator, function(err, actual) {
@@ -371,11 +373,12 @@ tape('create', function(test) {
 
     var hierarchies_finder = function() {
       return [
-        wofRecords['1']
+        [
+          wofRecords['1']
+        ]
       ];
     };
 
-    // seed the parent_id_walker with wofRecords
     var docGenerator = peliasDocGenerators.create(hierarchies_finder);
 
     test_stream(input, docGenerator, function(err, actual) {
@@ -414,11 +417,12 @@ tape('create', function(test) {
 
     var hierarchies_finder = function() {
       return [
-        wofRecords['1']
+        [
+          wofRecords['1']
+        ]
       ];
     };
 
-    // seed the parent_id_walker with wofRecords
     var docGenerator = peliasDocGenerators.create(hierarchies_finder);
 
     test_stream(input, docGenerator, function(err, actual) {
@@ -458,11 +462,12 @@ tape('create', function(test) {
 
     var hierarchies_finder = function() {
       return [
-        wofRecords['1']
+        [
+          wofRecords['1']
+        ]
       ];
     };
 
-    // seed the parent_id_walker with wofRecords
     var docGenerator = peliasDocGenerators.create(hierarchies_finder);
 
     test_stream(input, docGenerator, function(err, actual) {
@@ -472,31 +477,28 @@ tape('create', function(test) {
 
   });
 
-  test.test('hierarchy should be walked to populate parentage', function(t) {
+  test.test('a document should be created for each available hierarchy', function(t) {
     var wofRecords = {
       1: {
         id: 1,
         name: 'neighbourhood name',
         lat: 12.121212,
         lon: 21.212121,
-        place_type: 'neighbourhood',
-        iso2: 'US'
+        place_type: 'neighbourhood'
       },
       2: {
         id: 2,
-        name: 'locality name',
+        name: 'country name 1',
         lat: 13.131313,
         lon: 31.313131,
-        place_type: 'locality',
-        iso2: 'US'
+        place_type: 'country'
       },
       3: {
         id: 3,
-        name: 'region name',
+        name: 'country name 2',
         lat: 14.141414,
         lon: 41.414141,
-        place_type: 'region',
-        iso2: 'US'
+        place_type: 'country'
       }
     };
 
@@ -511,19 +513,27 @@ tape('create', function(test) {
         .setName('default', 'neighbourhood name')
         .setCentroid({ lat: 12.121212, lon: 21.212121 })
         .addParent( 'neighbourhood', 'neighbourhood name', '1')
-        .addParent( 'locality', 'locality name', '2')
-        .addParent( 'region', 'region name', '3')
+        .addParent( 'country', 'country name 1', '2'),
+      new Document( 'whosonfirst', 'neighbourhood', '1')
+        .setName('default', 'neighbourhood name')
+        .setCentroid({ lat: 12.121212, lon: 21.212121 })
+        .addParent( 'neighbourhood', 'neighbourhood name', '1')
+        .addParent( 'country', 'country name 2', '3')
     ];
 
     var hierarchies_finder = function() {
       return [
-        wofRecords['1'],
-        wofRecords['2'],
-        wofRecords['3']
+        [
+          wofRecords['1'],
+          wofRecords['2']
+        ],
+        [
+          wofRecords['1'],
+          wofRecords['3']
+        ]
       ];
     };
 
-    // seed the parent_id_walker with wofRecords
     var docGenerator = peliasDocGenerators.create(hierarchies_finder);
 
     test_stream(input, docGenerator, function(err, actual) {

--- a/test/readStreamTest.js
+++ b/test/readStreamTest.js
@@ -93,7 +93,8 @@ tape('readStream', function(test) {
         abbreviation: 'XY',
         bounding_box: '-13.691314,49.909613,1.771169,60.847886',
         population: 98765,
-        popularity: 87654
+        popularity: 87654,
+        hierarchies: []
       }, 'id 1234567 should have been loaded');
 
       t.deepEqual(wofAdminRecords[12345678], {
@@ -107,7 +108,8 @@ tape('readStream', function(test) {
         abbreviation: 'XY',
         bounding_box: '-24.539906,34.815009,69.033946,81.85871',
         population: undefined,
-        popularity: undefined
+        popularity: undefined,
+        hierarchies: []
       }, 'id 12345678 should have been loaded');
 
       t.end();


### PR DESCRIPTION
WOF supports multiple hierarchies per record, but previously, the importer only went with the last hierarchy in the array.  In this PR, all hierarchies are supported.  

Fixed #39 
Supersedes #40
Connected to #2 