### PR TITLE
Check node version

### DIFF
--- a/import.js
+++ b/import.js
@@ -5,11 +5,14 @@ var peliasDbclient = require( 'pelias-dbclient' );
 var peliasDocGenerators = require('./src/peliasDocGenerators');
 var wofRecordStream = require('./src/wofRecordStream');
 var hierarchyFinder = require('./src/hierarchyFinder');
+var checker = require('node-version-checker').default;
 
 function hasDataDirectory() {
   return peliasConfig.imports.hasOwnProperty('whosonfirst') &&
           peliasConfig.imports.whosonfirst.hasOwnProperty('datapath');
 }
+
+checker();
 
 if (!hasDataDirectory()) {
   console.error('Could not find whosonfirst data directory in configuration');

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "fs-extra": "^0.30.0",
     "iso3166-1": "^0.2.5",
     "lodash": "^4.5.1",
+    "node-version-checker": "^2.0.0",
     "pelias-config": "^1.0.3",
     "pelias-dbclient": "^1.0.1",
     "pelias-logger": "0.0.8",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pelias-whosonfirst",
   "engines": {
-    "node": "0.12"
+    "node": ">=0.12"
   },
   "description": "Importer for Who's on First",
   "main": "index.js",


### PR DESCRIPTION
Use [node-version-checker](https://www.npmjs.com/package/node-version-checker) to ensure Node 0.12 or above is used. Node 0.10 is not supported and fails in a confusing way. Thanks @easherma for helping us notice!

It generates a _reasonably_ friendly error message:

```Error: Current node version does not match the engines section of the package.json. Wanted >=0.12 but was v0.10.43```