### PR TITLE
fix: Use regex to test for correct error

### DIFF
--- a/test/components/loadJSONTest.js
+++ b/test/components/loadJSONTest.js
@@ -33,7 +33,7 @@ tape('loadJSON', function(test) {
 
     test_stream(input, loadJSON.create('./'), function(err, actual) {
       t.deepEqual(actual, expected, 'an empty object should have been returned');
-      t.equal(stderr, 'exception on this_is_not_json.json: [SyntaxError: Unexpected token h]\n');
+      t.ok(stderr.match(/SyntaxError: Unexpected token h/), 'error output present');
       t.end();
       unhook_intercept();
       fs.unlinkSync(input[0].path);


### PR DESCRIPTION
In Node 6, the error output for JSON parse exceptions now includes a
nice backtrace. Unfortunately our test was comparing exact output, so it
now fails. This regex checks that the part we care about is there
without expecting a specific output.