### PR TITLE
added helpful error message about git-lfs

### DIFF
--- a/src/components/loadJSON.js
+++ b/src/components/loadJSON.js
@@ -7,6 +7,9 @@ module.exports.create = function create_json_parse_stream(dataDirectory) {
       return JSON.parse(fs.readFileSync(dataDirectory + record.path));
     } catch (err) {
       console.error('exception on %s:', record.path, err);
+      console.error('Inability to parse JSON usually means that WOF has been cloned ' +
+                    'without using git-lfs, please see instructions here: ' +
+                    'https://github.com/whosonfirst/whosonfirst-data#git-and-large-files');
       return {};
     }
   });


### PR DESCRIPTION
The additional error message is targeted to users who failed to take https://github.com/whosonfirst/whosonfirst-data/blob/master/README.md (specifically https://github.com/whosonfirst/whosonfirst-data/blob/master/README.md#git-and-large-files) under advisement when cloning WOF data and encounter recoverable errors during import.

#103 