### PR TITLE
Use a single stream for importing records

### DIFF
--- a/import.js
+++ b/import.js
@@ -1,9 +1,8 @@
 var peliasConfig = require( 'pelias-config' ).generate();
-var readStream = require('./src/readStream');
+var readStreamModule = require('./src/readStream');
 var importStream = require('./src/importStream');
 var peliasDbclient = require( 'pelias-dbclient' );
 var peliasDocGenerators = require('./src/peliasDocGenerators');
-var wofRecordStream = require('./src/wofRecordStream');
 var hierarchyFinder = require('./src/hierarchyFinder');
 var checker = require('node-version-checker').default;
 
@@ -43,24 +42,20 @@ var types = [
   'neighbourhood'
 ];
 
-var wofRecords = {};
+// a cache of only admin records, to be used to fill the hierarchy
+// of other, lower admin records as well as venues
+var wofAdminRecords = {};
 
-readStream(directory, types, wofRecords, function() {
-  console.log(Object.keys(wofRecords).length + ' records loaded');
+var readStream = readStreamModule.create(directory, types, wofAdminRecords);
 
-  // a stream of WOF records
-  var recordStream = wofRecordStream.createWofRecordsStream(wofRecords);
+// how to convert WOF records to Pelias Documents
+var documentGenerator = peliasDocGenerators.create(
+  hierarchyFinder.hierarchies_walker(wofAdminRecords));
 
-  // how to convert WOF records to Pelias Documents
-  var documentGenerator = peliasDocGenerators.create(
-    hierarchyFinder.hierarchies_walker(wofRecords));
+// the final destination of Pelias Documents
+var dbClientStream = peliasDbclient();
 
-  // the final destination of Pelias Documents
-  var dbClientStream = peliasDbclient();
-
-  // import WOF records into ES
-  importStream(recordStream, documentGenerator, dbClientStream, function() {
-    console.log('import finished');
-  });
-
+// import WOF records into ES
+importStream(readStream, documentGenerator, dbClientStream, function() {
+  console.log('import finished');
 });

--- a/import.js
+++ b/import.js
@@ -25,19 +25,22 @@ if (directory.slice(-1) !== '/') {
   directory = directory + '/';
 }
 
+// types must be in highest to lowest level order
+// see https://github.com/whosonfirst/whosonfirst-placetypes
+// venue data goes last
 var types = [
-  'borough',
   'continent',
   'country',
-  'county',
   'dependency',
   'disputed',
+  'macroregion',
+  'region',
+  'county',
+  'macrocounty',
   'localadmin',
   'locality',
-  'macrocounty',
-  'macroregion',
-  'neighbourhood',
-  'region'
+  'borough',
+  'neighbourhood'
 ];
 
 var wofRecords = {};

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "batchflow": "^0.4.0",
     "clone": "^1.0.2",
+    "combined-stream": "^1.0.5",
     "csv-parse": "^1.0.0",
     "fs-extra": "^0.30.0",
     "iso3166-1": "^0.2.5",

--- a/test/readStreamTest.js
+++ b/test/readStreamTest.js
@@ -1,5 +1,6 @@
 var tape = require('tape');
 var fs = require('fs-extra');
+var sink = require('through2-sink');
 
 var readStream = require('../src/readStream');
 
@@ -8,7 +9,7 @@ tape('readStream', function(test) {
     this test is not terribly attractive, i'm not happy with it but setup wasn't
     all that painful.
   */
-  test.test('readStream should return from all requested types and populate wofRecords', function(t) {
+  test.test('readStream should return from all requested types and populate wofAdminRecords', function(t) {
     function setupTestEnvironment() {
       // remove tmp directory if for some reason it's been hanging around from a previous run
       fs.removeSync('tmp');
@@ -75,12 +76,13 @@ tape('readStream', function(test) {
 
     setupTestEnvironment();
 
-    var wofRecords = {};
+    var wofAdminRecords = {};
+    var stream = readStream.create('./tmp/', ['type1', 'type2'], wofAdminRecords);
 
-    readStream('./tmp/', ['type1', 'type2'], wofRecords, function() {
-      t.equals(Object.keys(wofRecords).length, 2, 'there should be 2 records loaded');
+    stream.pipe(sink.obj(function() {})).on('finish', function() {
+      t.equals(Object.keys(wofAdminRecords).length, 2, 'there should be 2 records loaded');
 
-      t.deepEqual(wofRecords[1234567], {
+      t.deepEqual(wofAdminRecords[1234567], {
         id: 1234567,
         name: 'name 1',
         place_type: 'place type 1',
@@ -94,7 +96,7 @@ tape('readStream', function(test) {
         popularity: 87654
       }, 'id 1234567 should have been loaded');
 
-      t.deepEqual(wofRecords[12345678], {
+      t.deepEqual(wofAdminRecords[12345678], {
         id: 12345678,
         name: 'name 2',
         place_type: 'place type 2',

--- a/test/readStreamTest.js
+++ b/test/readStreamTest.js
@@ -67,12 +67,10 @@ tape('readStream', function(test) {
           'geom:bbox': '-24.539906,34.815009,69.033946,81.85871'
         }
       }));
-
     }
 
     function cleanupTestEnvironment() {
       fs.removeSync('tmp');
-
     }
 
     setupTestEnvironment();
@@ -113,9 +111,6 @@ tape('readStream', function(test) {
       t.end();
 
       cleanupTestEnvironment();
-
     });
-
   });
-
 });


### PR DESCRIPTION
Previously, the WOF importer loaded all records into memory in one
stream, and then processed and indexed the records in Elasticsearch in a
second stream after the first stream was done.

This has several problems:
* It requires that all data can fit into memory. While this is not
  _so_ bad for WOF admin data, where a reasonably new machine can handle
  things just fine, it's horrible for venue data, where there are already
  10s of millions of records and will likely be many more in the future.
* Its slower: by separating the disk and network I/O sections, they
  can't be interleaved to speed things up.
* It doesn't give good feedback when running the importer that something
  is happening: the importer sits for several minutes loading records
  before the dbclient progress logs start displaying

This change fixes all those issues, by processing all records in a
single stream, starting at the highest hierarchy level, and finishing at
the lowest, so that all records always have the admin data they need to
be processed.

A change like this is necessary to support Who's on First venues, and in fact this code has already been tested by importing about 1M venues from California!

Fixes #101
Connects #7 (it doesn't quite fix it, for that we need to be able to not even store all _admin_ areas at once, for example to import geometries)
Connects #94 
