### PR TITLE
Use lbl:bbox property when present

### DIFF
--- a/src/components/extractFields.js
+++ b/src/components/extractFields.js
@@ -38,6 +38,14 @@ function getLon(properties) {
   }
 }
 
+function getBoundingBox(properties) {
+  if (properties['lbl:bbox']) {
+    return properties['lbl:bbox'];
+  } else {
+    return properties['geom:bbox'];
+  }
+}
+
 /*
   This function extracts the fields from the json_object that we're interested
   in for creating Pelias Document objects.  If there is no hierarchy then a
@@ -54,7 +62,7 @@ module.exports.create = function map_fields_stream() {
       parent_id: json_object.properties['wof:parent_id'],
       lat: getLat(json_object.properties),
       lon: getLon(json_object.properties),
-      bounding_box: json_object.properties['geom:bbox'],
+      bounding_box: getBoundingBox(json_object.properties),
       iso2: json_object.properties['iso:country'],
       population: getPopulation(json_object.properties),
       popularity: json_object.properties['misc:photo_sum']

--- a/src/components/extractFields.js
+++ b/src/components/extractFields.js
@@ -39,7 +39,7 @@ function getLon(properties) {
 }
 
 function getBoundingBox(properties) {
-  if (properties['lbl:bbox']) {
+  if (properties.hasOwnProperty('lbl:bbox')) {
     return properties['lbl:bbox'];
   } else {
     return properties['geom:bbox'];

--- a/test/components/extractFieldsTest.js
+++ b/test/components/extractFieldsTest.js
@@ -591,4 +591,43 @@ tape('readStreamComponents', function(test) {
       t.end();
     });
   });
+
+  test.test('label bounding box should take precedence over math bounding box even if empty', function(t) {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:placetype': 'county',
+          'wof:parent_id': 'parent id',
+          'geom:latitude': 12.121212,
+          'geom:longitude': 21.212121,
+          'geom:bbox': '-13.691314,49.909613,1.771169,60.847886',
+          'lbl:bbox': '',
+          'qs:a2_alt': 'qs:a2_alt value'
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'wof:name value',
+        place_type: 'county',
+        parent_id: 'parent id',
+        lat: 12.121212,
+        lon: 21.212121,
+        iso2: undefined,
+        population: undefined,
+        popularity: undefined,
+        bounding_box: '',
+        abbreviation: undefined
+      }
+    ];
+
+    test_stream(input, extractFields.create(), function(err, actual) {
+      t.deepEqual(actual, expected, 'label geometry is used');
+      t.end();
+    });
+  });
 });

--- a/test/components/extractFieldsTest.js
+++ b/test/components/extractFieldsTest.js
@@ -552,4 +552,43 @@ tape('readStreamComponents', function(test) {
       t.end();
     });
   });
+
+  test.test('label bounding box should take precedence over math bounding box', function(t) {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:placetype': 'county',
+          'wof:parent_id': 'parent id',
+          'geom:latitude': 12.121212,
+          'geom:longitude': 21.212121,
+          'geom:bbox': '-13.691314,49.909613,1.771169,60.847886',
+          'lbl:bbox': '-14.691314,50.909613,2.771169,61.847886',
+          'qs:a2_alt': 'qs:a2_alt value'
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'wof:name value',
+        place_type: 'county',
+        parent_id: 'parent id',
+        lat: 12.121212,
+        lon: 21.212121,
+        iso2: undefined,
+        population: undefined,
+        popularity: undefined,
+        bounding_box: '-14.691314,50.909613,2.771169,61.847886',
+        abbreviation: undefined
+      }
+    ];
+
+    test_stream(input, extractFields.create(), function(err, actual) {
+      t.deepEqual(actual, expected, 'label geometry is used');
+      t.end();
+    });
+  });
 });


### PR DESCRIPTION
After the discussion in https://github.com/pelias/pelias/issues/370,
Who's on First implemented the `lbl:bbox` field, which is a hand-made
bounding box for areas where the mathematically derived bounding box
doesn't match up with what people generally want.

At least two of these were implemented in
https://github.com/whosonfirst-data/whosonfirst-data/issues/361, so it's
time to start using them!

Connects https://github.com/pelias/pelias/issues/370
Connects https://github.com/pelias/pelias/issues/397