### PR TITLE
use `wof:label` for name instead of `wof:name` when available

### DIFF
--- a/src/components/extractFields.js
+++ b/src/components/extractFields.js
@@ -46,6 +46,14 @@ function getBoundingBox(properties) {
   }
 }
 
+function getName(properties) {
+  if (properties.hasOwnProperty('wof:label')) {
+    return properties['wof:label'];
+  } else {
+    return properties['wof:name'];
+  }
+}
+
 /*
   This function extracts the fields from the json_object that we're interested
   in for creating Pelias Document objects.  If there is no hierarchy then a
@@ -56,7 +64,7 @@ module.exports.create = function map_fields_stream() {
   return through2.obj(function(json_object, enc, callback) {
     var base_record = {
       id: json_object.id,
-      name: json_object.properties['wof:name'],
+      name: getName(json_object.properties),
       abbreviation: json_object.properties['wof:abbreviation'],
       place_type: json_object.properties['wof:placetype'],
       parent_id: json_object.properties['wof:parent_id'],

--- a/test/components/extractFieldsTest.js
+++ b/test/components/extractFieldsTest.js
@@ -630,4 +630,44 @@ tape('readStreamComponents', function(test) {
       t.end();
     });
   });
+
+  test.test('wof:label should be used for name when both it and wof:name are available', function(t) {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:label': 'wof:label value',
+          'wof:placetype': 'county',
+          'wof:parent_id': 'parent id',
+          'geom:latitude': 12.121212,
+          'geom:longitude': 21.212121,
+          'lbl:bbox': ''
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'wof:label value',
+        place_type: 'county',
+        parent_id: 'parent id',
+        lat: 12.121212,
+        lon: 21.212121,
+        iso2: undefined,
+        population: undefined,
+        popularity: undefined,
+        bounding_box: '',
+        abbreviation: undefined
+      }
+    ];
+
+    test_stream(input, extractFields.create(), function(err, actual) {
+      t.deepEqual(actual, expected, 'wof:label is used for name');
+      t.end();
+    });
+
+  });
+
 });


### PR DESCRIPTION
Fixed #134 