### PR TITLE
Read venue import and download settings from config

### DIFF
--- a/download_data.js
+++ b/download_data.js
@@ -21,8 +21,14 @@ function generateCommand(type, directory) {
   return 'curl https://whosonfirst.mapzen.com/bundles/wof-' + type + '-latest-bundle.tar.bz2 | tar -xj --strip-components=1 --exclude=README.txt -C ' + directory + ' && mv ' + directory + '/wof-' + type  + '-latest.csv ' + directory + '/meta/';
 }
 
-var bundlesToDownload = bundles.allBundles;
+var bundlesToDownload = bundles.hierarchyBundles;
 
+if (config.imports.whosonfirst.importVenues) {
+  bundlesToDownload = bundlesToDownload.concat(bundles.venueBundles);
+}
+
+// this should override the config setting since the hierarchy bundles are useful
+// on their own to allow other importers to start when using admin lookup
 if (process.argv[2] == '--admin-only') {
   bundlesToDownload = bundles.hierarchyBundles;
 }

--- a/import.js
+++ b/import.js
@@ -29,7 +29,13 @@ if (directory.slice(-1) !== '/') {
 // of other, lower admin records as well as venues
 var wofAdminRecords = {};
 
-var readStream = readStreamModule.create(directory, bundles.allBundles, wofAdminRecords);
+var bundlesToImport = bundles.hierarchyBundles;
+
+if (peliasConfig.imports.whosonfirst.importVenues) {
+  bundlesToImport = bundlesToImport.concat(bundles.venueBundles);
+}
+
+var readStream = readStreamModule.create(directory, bundlesToImport, wofAdminRecords);
 
 // how to convert WOF records to Pelias Documents
 var documentGenerator = peliasDocGenerators.create(


### PR DESCRIPTION
Both the downloader script and importer now read the [venues config setting](https://github.com/pelias/config/pull/35) to decide whether or not to import venues. The corresponding PR to pelias/config makes the venue import default to false, so merging these two PRs will also disable importing venues unless configured otherwise.