### PR TITLE
Require Node.js 4.0 or greater

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache:
 notifications:
   email: false
 node_js:
-  - 0.12
   - 4
   - 6
 matrix:

--- a/import.js
+++ b/import.js
@@ -4,15 +4,16 @@ var importStream = require('./src/importStream');
 var peliasDbclient = require( 'pelias-dbclient' );
 var peliasDocGenerators = require('./src/peliasDocGenerators');
 var hierarchyFinder = require('./src/hierarchyFinder');
-var checker = require('node-version-checker').default;
+var version_checker = require('node-version-checker').default;
 var bundles = require('./src/bundleList');
+
+// print a warning if an unsupported Node.JS version is used
+version_checker();
 
 function hasDataDirectory() {
   return peliasConfig.imports.hasOwnProperty('whosonfirst') &&
           peliasConfig.imports.whosonfirst.hasOwnProperty('datapath');
 }
-
-checker();
 
 if (!hasDataDirectory()) {
   console.error('Could not find whosonfirst data directory in configuration');

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pelias-whosonfirst",
   "version": "0.0.0-semantic-release",
   "engines": {
-    "node": ">=0.12"
+    "node": ">=4.0.0"
   },
   "description": "Importer for Who's on First",
   "main": "index.js",


### PR DESCRIPTION
connects pelias/pelias#404

This also includes some slight cleanup of the version checking code, which we should probably port to the other main pelias repositories.