### PR TITLE
Remove iso2 support

### DIFF
--- a/src/components/extractFields.js
+++ b/src/components/extractFields.js
@@ -2,8 +2,8 @@ var through2 = require('through2');
 var _ = require('lodash');
 
 // this function is used to verify that a US county QS altname is available
-function isUsCounty(base_record, qs_a2_alt) {
-  return 'US' === base_record.iso2 &&
+function isUsCounty(base_record, wof_country, qs_a2_alt) {
+  return 'US' === wof_country &&
           'county' === base_record.place_type &&
           !_.isUndefined(qs_a2_alt);
 }
@@ -77,7 +77,7 @@ module.exports.create = function map_fields_stream() {
     };
 
     // use the QS altname if US county and available
-    if (isUsCounty(record, json_object.properties['qs:a2_alt'])) {
+    if (isUsCounty(record, json_object.properties['wof:country'], json_object.properties['qs:a2_alt'])) {
       record.name = json_object.properties['qs:a2_alt'];
     }
 

--- a/src/components/extractFields.js
+++ b/src/components/extractFields.js
@@ -54,6 +54,13 @@ function getName(properties) {
   }
 }
 
+function getAbbreviation(properties) {
+  if (properties['wof:placetype'] === 'country' && properties['wof:country']) {
+    return properties['wof:country'];
+  }
+  return properties['wof:abbreviation'];
+}
+
 /*
   This function extracts the fields from the json_object that we're interested
   in for creating Pelias Document objects.  If there is no hierarchy then a
@@ -65,12 +72,11 @@ module.exports.create = function map_fields_stream() {
     var record = {
       id: json_object.id,
       name: getName(json_object.properties),
-      abbreviation: json_object.properties['wof:abbreviation'],
+      abbreviation: getAbbreviation(json_object.properties),
       place_type: json_object.properties['wof:placetype'],
       lat: getLat(json_object.properties),
       lon: getLon(json_object.properties),
       bounding_box: getBoundingBox(json_object.properties),
-      iso2: json_object.properties['iso:country'],
       population: getPopulation(json_object.properties),
       popularity: json_object.properties['misc:photo_sum'],
       hierarchies: _.get(json_object, 'properties.wof:hierarchy', [])

--- a/src/peliasDocGenerators.js
+++ b/src/peliasDocGenerators.js
@@ -27,9 +27,9 @@ function assignField(hierarchyElement, wofDoc) {
       }
       break;
     case 'country':
-      // this is placetype=country, so lookup and set the iso3 from iso2
-      if (iso3166.is2(hierarchyElement.iso2)) {
-        var iso3 = iso3166.to3(hierarchyElement.iso2);
+      // this is placetype=country, so lookup and set the iso3 from abbreviation
+      if (iso3166.is2(hierarchyElement.abbreviation)) {
+        var iso3 = iso3166.to3(hierarchyElement.abbreviation);
 
         wofDoc.setAlpha3(iso3);
         wofDoc.addParent('country', hierarchyElement.name, hierarchyElement.id.toString(), iso3);

--- a/test/components/extractFieldsTest.js
+++ b/test/components/extractFieldsTest.js
@@ -391,7 +391,7 @@ tape('readStreamComponents', function(test) {
 
   });
 
-  test.test('wof:placetype=county and iso2:country=US should use qs:a2_alt for name', function(t) {
+  test.test('wof:placetype=county and wof:country=US should use qs:a2_alt for name', function(t) {
     var input = [
       {
         id: 12345,
@@ -401,6 +401,7 @@ tape('readStreamComponents', function(test) {
           'geom:latitude': 12.121212,
           'geom:longitude': 21.212121,
           'iso:country': 'US',
+          'wof:country': 'US',
           'qs:a2_alt': 'qs:a2_alt value'
         }
       }
@@ -514,9 +515,7 @@ tape('readStreamComponents', function(test) {
           'geom:latitude': 12.121212,
           'geom:longitude': 21.212121,
           'lbl:latitude': 14.141414,
-          'lbl:longitude': 23.232323,
-          'iso:country': 'not US',
-          'qs:a2_alt': 'qs:a2_alt value'
+          'lbl:longitude': 23.232323
         }
       }
     ];
@@ -528,7 +527,7 @@ tape('readStreamComponents', function(test) {
         place_type: 'county',
         lat: 14.141414,
         lon: 23.232323,
-        iso2: 'not US',
+        iso2: undefined,
         population: undefined,
         popularity: undefined,
         bounding_box: undefined,
@@ -553,8 +552,7 @@ tape('readStreamComponents', function(test) {
           'geom:latitude': 12.121212,
           'geom:longitude': 21.212121,
           'geom:bbox': '-13.691314,49.909613,1.771169,60.847886',
-          'lbl:bbox': '-14.691314,50.909613,2.771169,61.847886',
-          'qs:a2_alt': 'qs:a2_alt value'
+          'lbl:bbox': '-14.691314,50.909613,2.771169,61.847886'
         }
       }
     ];
@@ -591,8 +589,7 @@ tape('readStreamComponents', function(test) {
           'geom:latitude': 12.121212,
           'geom:longitude': 21.212121,
           'geom:bbox': '-13.691314,49.909613,1.771169,60.847886',
-          'lbl:bbox': '',
-          'qs:a2_alt': 'qs:a2_alt value'
+          'lbl:bbox': ''
         }
       }
     ];

--- a/test/components/extractFieldsTest.js
+++ b/test/components/extractFieldsTest.js
@@ -41,7 +41,6 @@ tape('readStreamComponents', function(test) {
               'country_id': 23456
             }
           ],
-          'iso:country': 'YZ',
           'wof:abbreviation': 'XY',
           'gn:population': 98765,
           'misc:photo_sum': 87654,
@@ -58,7 +57,6 @@ tape('readStreamComponents', function(test) {
         place_type: 'place type 1',
         lat: 12.121212,
         lon: 21.212121,
-        iso2: 'YZ',
         population: 98765,
         popularity: 87654,
         abbreviation: 'XY',
@@ -96,7 +94,6 @@ tape('readStreamComponents', function(test) {
         place_type: undefined,
         lat: undefined,
         lon: undefined,
-        iso2: undefined,
         population: undefined,
         popularity: undefined,
         abbreviation: undefined,
@@ -122,7 +119,6 @@ tape('readStreamComponents', function(test) {
           'geom:latitude': 12.121212,
           'geom:longitude': 21.212121,
           'geom:bbox': '-13.691314,49.909613,1.771169,60.847886',
-          'iso:country': 'YZ',
           'wof:abbreviation': 'XY',
           'gn:population': 98765,
           'zs:pop10': 87654
@@ -137,7 +133,6 @@ tape('readStreamComponents', function(test) {
         place_type: 'place type 1',
         lat: 12.121212,
         lon: 21.212121,
-        iso2: 'YZ',
         population: 98765,
         popularity: undefined,
         abbreviation: 'XY',
@@ -163,7 +158,6 @@ tape('readStreamComponents', function(test) {
           'geom:latitude': 12.121212,
           'geom:longitude': 21.212121,
           'geom:bbox': '-13.691314,49.909613,1.771169,60.847886',
-          'iso:country': 'YZ',
           'wof:abbreviation': 'XY',
           'zs:pop10': 98765
         }
@@ -177,7 +171,6 @@ tape('readStreamComponents', function(test) {
         place_type: 'place type 1',
         lat: 12.121212,
         lon: 21.212121,
-        iso2: 'YZ',
         population: 98765,
         popularity: undefined,
         abbreviation: 'XY',
@@ -203,7 +196,6 @@ tape('readStreamComponents', function(test) {
           'geom:latitude': 12.121212,
           'geom:longitude': 21.212121,
           'geom:bbox': '-13.691314,49.909613,1.771169,60.847886',
-          'iso:country': 'YZ',
           'wof:abbreviation': 'XY',
           'qs:pop': 98765
         }
@@ -217,7 +209,6 @@ tape('readStreamComponents', function(test) {
         place_type: 'place type 1',
         lat: 12.121212,
         lon: 21.212121,
-        iso2: 'YZ',
         population: 98765,
         popularity: undefined,
         abbreviation: 'XY',
@@ -243,7 +234,6 @@ tape('readStreamComponents', function(test) {
           'geom:latitude': 12.121212,
           'geom:longitude': 21.212121,
           'geom:bbox': '-13.691314,49.909613,1.771169,60.847886',
-          'iso:country': 'YZ',
           'wof:abbreviation': 'XY',
           'mz:population': 98765
         }
@@ -257,7 +247,6 @@ tape('readStreamComponents', function(test) {
         place_type: 'place type 1',
         lat: 12.121212,
         lon: 21.212121,
-        iso2: 'YZ',
         population: 98765,
         popularity: undefined,
         abbreviation: 'XY',
@@ -283,7 +272,6 @@ tape('readStreamComponents', function(test) {
           'geom:latitude': 12.121212,
           'geom:longitude': 21.212121,
           'geom:bbox': '-13.691314,49.909613,1.771169,60.847886',
-          'iso:country': 'YZ',
           'wof:abbreviation': 'XY',
           'zs:pop10': 0
         }
@@ -297,7 +285,6 @@ tape('readStreamComponents', function(test) {
         place_type: 'place type 1',
         lat: 12.121212,
         lon: 21.212121,
-        iso2: 'YZ',
         population: undefined,
         popularity: undefined,
         abbreviation: 'XY',
@@ -323,7 +310,6 @@ tape('readStreamComponents', function(test) {
           'geom:latitude': 12.121212,
           'geom:longitude': 21.212121,
           'geom:bbox': '-13.691314,49.909613,1.771169,60.847886',
-          'iso:country': 'YZ',
           'wof:abbreviation': 'XY'
         }
       }
@@ -336,7 +322,6 @@ tape('readStreamComponents', function(test) {
         place_type: 'place type 1',
         lat: 12.121212,
         lon: 21.212121,
-        iso2: 'YZ',
         population: undefined,
         popularity: undefined,
         abbreviation: 'XY',
@@ -362,7 +347,6 @@ tape('readStreamComponents', function(test) {
           'geom:latitude': 12.121212,
           'geom:longitude': 21.212121,
           'geom:bbox': '-13.691314,49.909613,1.771169,60.847886',
-          'iso:country': 'YZ',
           'wof:abbreviation': 'XY'
         }
       }
@@ -375,7 +359,6 @@ tape('readStreamComponents', function(test) {
         place_type: 'place type 1',
         lat: 12.121212,
         lon: 21.212121,
-        iso2: 'YZ',
         population: undefined,
         popularity: undefined,
         abbreviation: 'XY',
@@ -414,7 +397,6 @@ tape('readStreamComponents', function(test) {
         place_type: 'county',
         lat: 12.121212,
         lon: 21.212121,
-        iso2: 'US',
         population: undefined,
         popularity: undefined,
         bounding_box: undefined,
@@ -451,7 +433,6 @@ tape('readStreamComponents', function(test) {
         place_type: 'county',
         lat: 12.121212,
         lon: 21.212121,
-        iso2: 'US',
         population: undefined,
         popularity: undefined,
         bounding_box: undefined,
@@ -489,7 +470,6 @@ tape('readStreamComponents', function(test) {
         place_type: 'county',
         lat: 12.121212,
         lon: 21.212121,
-        iso2: 'not US',
         population: undefined,
         popularity: undefined,
         bounding_box: undefined,
@@ -526,7 +506,6 @@ tape('readStreamComponents', function(test) {
         place_type: undefined,
         lat: 14.141414,
         lon: 23.232323,
-        iso2: undefined,
         population: undefined,
         popularity: undefined,
         bounding_box: undefined,
@@ -562,7 +541,6 @@ tape('readStreamComponents', function(test) {
         place_type: undefined,
         lat: 12.121212,
         lon: 21.212121,
-        iso2: undefined,
         population: undefined,
         popularity: undefined,
         bounding_box: '-14.691314,50.909613,2.771169,61.847886',
@@ -598,7 +576,6 @@ tape('readStreamComponents', function(test) {
         place_type: undefined,
         lat: 12.121212,
         lon: 21.212121,
-        iso2: undefined,
         population: undefined,
         popularity: undefined,
         bounding_box: '',
@@ -634,7 +611,6 @@ tape('readStreamComponents', function(test) {
         place_type: undefined,
         lat: 12.121212,
         lon: 21.212121,
-        iso2: undefined,
         population: undefined,
         popularity: undefined,
         bounding_box: '',
@@ -645,6 +621,76 @@ tape('readStreamComponents', function(test) {
 
     test_stream(input, extractFields.create(), function(err, actual) {
       t.deepEqual(actual, expected, 'wof:label is used for name');
+      t.end();
+    });
+
+  });
+
+  test.test('wof:placetype=country should use wof:country value for abbreviation', function(t) {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:placetype': 'country',
+          'wof:country': 'XY',
+          'wof:abbreviation': 'YZ'
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'wof:name value',
+        place_type: 'country',
+        lat: undefined,
+        lon: undefined,
+        population: undefined,
+        popularity: undefined,
+        bounding_box: undefined,
+        abbreviation: 'XY',
+        hierarchies: []
+      }
+    ];
+
+    test_stream(input, extractFields.create(), function(err, actual) {
+      t.deepEqual(actual, expected, 'wof:country is used for abbreviation');
+      t.end();
+    });
+
+  });
+
+  test.test('wof:placetype=country should use wof:abbreviation value for abbreviation when wof:country is undefined', function(t) {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:placetype': 'country',
+          'wof:country': undefined,
+          'wof:abbreviation': 'YZ'
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'wof:name value',
+        place_type: 'country',
+        lat: undefined,
+        lon: undefined,
+        population: undefined,
+        popularity: undefined,
+        bounding_box: undefined,
+        abbreviation: 'YZ',
+        hierarchies: []
+      }
+    ];
+
+    test_stream(input, extractFields.create(), function(err, actual) {
+      t.deepEqual(actual, expected, 'wof:abbreviation is used for abbreviation');
       t.end();
     });
 

--- a/test/components/extractFieldsTest.js
+++ b/test/components/extractFieldsTest.js
@@ -511,7 +511,6 @@ tape('readStreamComponents', function(test) {
         id: 12345,
         properties: {
           'wof:name': 'wof:name value',
-          'wof:placetype': 'county',
           'geom:latitude': 12.121212,
           'geom:longitude': 21.212121,
           'lbl:latitude': 14.141414,
@@ -524,7 +523,7 @@ tape('readStreamComponents', function(test) {
       {
         id: 12345,
         name: 'wof:name value',
-        place_type: 'county',
+        place_type: undefined,
         lat: 14.141414,
         lon: 23.232323,
         iso2: undefined,
@@ -548,7 +547,6 @@ tape('readStreamComponents', function(test) {
         id: 12345,
         properties: {
           'wof:name': 'wof:name value',
-          'wof:placetype': 'county',
           'geom:latitude': 12.121212,
           'geom:longitude': 21.212121,
           'geom:bbox': '-13.691314,49.909613,1.771169,60.847886',
@@ -561,7 +559,7 @@ tape('readStreamComponents', function(test) {
       {
         id: 12345,
         name: 'wof:name value',
-        place_type: 'county',
+        place_type: undefined,
         lat: 12.121212,
         lon: 21.212121,
         iso2: undefined,
@@ -585,7 +583,6 @@ tape('readStreamComponents', function(test) {
         id: 12345,
         properties: {
           'wof:name': 'wof:name value',
-          'wof:placetype': 'county',
           'geom:latitude': 12.121212,
           'geom:longitude': 21.212121,
           'geom:bbox': '-13.691314,49.909613,1.771169,60.847886',
@@ -598,7 +595,7 @@ tape('readStreamComponents', function(test) {
       {
         id: 12345,
         name: 'wof:name value',
-        place_type: 'county',
+        place_type: undefined,
         lat: 12.121212,
         lon: 21.212121,
         iso2: undefined,
@@ -623,7 +620,6 @@ tape('readStreamComponents', function(test) {
         properties: {
           'wof:name': 'wof:name value',
           'wof:label': 'wof:label value',
-          'wof:placetype': 'county',
           'geom:latitude': 12.121212,
           'geom:longitude': 21.212121,
           'lbl:bbox': ''
@@ -635,7 +631,7 @@ tape('readStreamComponents', function(test) {
       {
         id: 12345,
         name: 'wof:label value',
-        place_type: 'county',
+        place_type: undefined,
         lat: 12.121212,
         lon: 21.212121,
         iso2: undefined,

--- a/test/peliasDocGeneratorsTest.js
+++ b/test/peliasDocGeneratorsTest.js
@@ -21,8 +21,7 @@ tape('create', function(test) {
           name: 'record name',
           lat: 12.121212,
           lon: 21.212121,
-          place_type: place_type,
-          iso2: 'DE'
+          place_type: place_type
         }
       };
 
@@ -68,8 +67,7 @@ tape('create', function(test) {
           abbreviation: 'record abbreviation',
           lat: 12.121212,
           lon: 21.212121,
-          place_type: place_type,
-          iso2: 'DE'
+          place_type: place_type
         }
       };
 
@@ -214,7 +212,7 @@ tape('create', function(test) {
 
   });
 
-  test.test('record without iso2 should not set alpha3', function(t) {
+  test.test('country record without abbreviation should not set alpha3', function(t) {
     var wofRecords = {
       1: {
         id: 1,
@@ -255,7 +253,7 @@ tape('create', function(test) {
 
   });
 
-  test.test('record with unknown iso2 should not set alpha3', function(t) {
+  test.test('country record with unknown abbreviation should not set alpha3', function(t) {
     var wofRecords = {
       1: {
         id: 1,
@@ -263,7 +261,7 @@ tape('create', function(test) {
         lat: 12.121212,
         lon: 21.212121,
         place_type: 'country',
-        iso2: 'this is not a known ISO2 country code'
+        abbreviation: 'this is not a known ISO2 country code'
       }
     };
 
@@ -305,7 +303,7 @@ tape('create', function(test) {
         lat: 12.121212,
         lon: 21.212121,
         place_type: 'country',
-        iso2: 'US',
+        abbreviation: 'US',
         population: undefined
       }
     };
@@ -349,7 +347,7 @@ tape('create', function(test) {
         lat: 12.121212,
         lon: 21.212121,
         place_type: 'country',
-        iso2: 'US',
+        abbreviation: 'US',
         population: 98765
       }
     };
@@ -394,7 +392,7 @@ tape('create', function(test) {
         lat: 12.121212,
         lon: 21.212121,
         place_type: 'country',
-        iso2: 'US',
+        abbreviation: 'US',
         popularity: undefined
       }
     };
@@ -438,7 +436,7 @@ tape('create', function(test) {
         lat: 12.121212,
         lon: 21.212121,
         place_type: 'country',
-        iso2: 'US',
+        abbreviation: 'US',
         popularity: 87654
       }
     };

--- a/test/readStreamTest.js
+++ b/test/readStreamTest.js
@@ -26,7 +26,6 @@ tape('readStream', function(test) {
           'wof:placetype': 'place type 1',
           'geom:latitude': 12.121212,
           'geom:longitude': 21.212121,
-          'iso:country': 'YZ',
           'wof:abbreviation': 'XY',
           'geom:bbox': '-13.691314,49.909613,1.771169,60.847886',
           'gn:population': 98765,
@@ -44,7 +43,6 @@ tape('readStream', function(test) {
           'wof:placetype': 'place type 2',
           'geom:latitude': 13.131313,
           'geom:longitude': 31.313131,
-          'iso:country': 'XZ',
           'wof:abbreviation': 'XY',
           'geom:bbox': '-24.539906,34.815009,69.033946,81.85871'
         }
@@ -85,7 +83,6 @@ tape('readStream', function(test) {
         place_type: 'place type 1',
         lat: 12.121212,
         lon: 21.212121,
-        iso2: 'YZ',
         abbreviation: 'XY',
         bounding_box: '-13.691314,49.909613,1.771169,60.847886',
         population: 98765,
@@ -99,7 +96,6 @@ tape('readStream', function(test) {
         place_type: 'place type 2',
         lat: 13.131313,
         lon: 31.313131,
-        iso2: 'XZ',
         abbreviation: 'XY',
         bounding_box: '-24.539906,34.815009,69.033946,81.85871',
         population: undefined,


### PR DESCRIPTION
`country` records now use `wof:country` for ISO which is then used when traversing the hierarchies for setting `alpha3`