### PR TITLE
Fail on read errors

### DIFF
--- a/src/components/loadJSON.js
+++ b/src/components/loadJSON.js
@@ -5,9 +5,10 @@ var maxInFlight = 10;
 
 module.exports.create = function create_json_parse_stream(dataDirectory) {
   return parallelStream(maxInFlight, function(record, enc, next) {
-    fs.readFile(dataDirectory + record.path, function(err, data) {
+    var full_file_path = dataDirectory + record.path;
+    fs.readFile(full_file_path, function(err, data) {
       if (err) {
-        console.error('exception reading file ' + record.path);
+        console.error('exception reading file ' + full_file_path);
         next(err);
       } else {
         try {

--- a/src/components/loadJSON.js
+++ b/src/components/loadJSON.js
@@ -14,7 +14,7 @@ module.exports.create = function create_json_parse_stream(dataDirectory) {
           var object = JSON.parse(data);
           next(null, object);
         } catch (parse_err) {
-          console.error('exception on %s:', record.path, parse_err);
+          console.error('exception parsing JSON in file %s:', record.path, parse_err);
           console.error('Inability to parse JSON usually means that WOF has been cloned ' +
                         'without using git-lfs, please see instructions here: ' +
                         'https://github.com/whosonfirst/whosonfirst-data#git-and-large-files');

--- a/src/components/loadJSON.js
+++ b/src/components/loadJSON.js
@@ -17,7 +17,7 @@ module.exports.create = function create_json_parse_stream(dataDirectory) {
           console.error('Inability to parse JSON usually means that WOF has been cloned ' +
                         'without using git-lfs, please see instructions here: ' +
                         'https://github.com/whosonfirst/whosonfirst-data#git-and-large-files');
-          next(null, {});
+          next(parse_err);
         }
       }
     });

--- a/src/components/loadJSON.js
+++ b/src/components/loadJSON.js
@@ -7,6 +7,7 @@ module.exports.create = function create_json_parse_stream(dataDirectory) {
   return parallelStream(maxInFlight, function(record, enc, next) {
     fs.readFile(dataDirectory + record.path, function(err, data) {
       if (err) {
+        console.error('exception reading file ' + record.path);
         next(err);
       } else {
         try {

--- a/test/components/loadJSONTest.js
+++ b/test/components/loadJSONTest.js
@@ -22,13 +22,12 @@ function test_stream(input, testedStream, callback, error_callback) {
 }
 
 tape('loadJSON', function(test) {
-  test.test('json_parse_stream should return an empty object if the file is not json', function(t) {
+  test.test('json_parse_stream should throw error if the file is not json', function(t) {
     var input = [
       {
         path: 'this_is_not_json.json'
       }
     ];
-    var expected = [{}];
 
     var stderr = '';
 
@@ -40,8 +39,8 @@ tape('loadJSON', function(test) {
 
     fs.writeFileSync(input[0].path, 'this is not JSON');
 
-    test_stream(input, loadJSON.create('./'), function(err, actual) {
-      t.deepEqual(actual, expected, 'an empty object should have been returned');
+    test_stream(input, loadJSON.create('./'), undefined, function(err, actual) {
+      t.deepEqual(actual, undefined, 'an error should be thrown');
       t.ok(stderr.match(/SyntaxError: Unexpected token h/), 'error output present');
       t.end();
       unhook_intercept();

--- a/test/components/loadJSONTest.js
+++ b/test/components/loadJSONTest.js
@@ -22,6 +22,30 @@ function test_stream(input, testedStream, callback, error_callback) {
 }
 
 tape('loadJSON', function(test) {
+  test.test('json_parse_stream should throw error if the file is not readable', function(t) {
+    var input = [
+      {
+        path: 'this_file_does_not_exist.json'
+      }
+    ];
+
+    var stderr = '';
+
+    // intercept/swallow stderr
+    var unhook_intercept = intercept(
+      function() { },
+      function(txt) { stderr += txt; return ''; }
+    );
+
+    test_stream(input, loadJSON.create('./'), undefined, function(err, actual) {
+      t.deepEqual(actual, undefined, 'an error should be thrown');
+      t.ok(stderr.match(/exception reading file/), 'error output present');
+      console.log(stderr);
+      unhook_intercept();
+      t.end();
+    });
+  });
+
   test.test('json_parse_stream should throw error if the file is not json', function(t) {
     var input = [
       {
@@ -42,9 +66,9 @@ tape('loadJSON', function(test) {
     test_stream(input, loadJSON.create('./'), undefined, function(err, actual) {
       t.deepEqual(actual, undefined, 'an error should be thrown');
       t.ok(stderr.match(/SyntaxError: Unexpected token h/), 'error output present');
-      t.end();
       unhook_intercept();
       fs.unlinkSync(input[0].path);
+      t.end();
     });
 
   });

--- a/test/components/loadJSONTest.js
+++ b/test/components/loadJSONTest.js
@@ -5,11 +5,20 @@ var fs = require('fs');
 
 var loadJSON = require('../../src/components/loadJSON');
 
-function test_stream(input, testedStream, callback) {
+function test_stream(input, testedStream, callback, error_callback) {
+    if (!error_callback) {
+      error_callback = function() {};
+    }
+
+    if (!callback) {
+      callback = function() {};
+    }
+
     var input_stream = event_stream.readArray(input);
     var destination_stream = event_stream.writeArray(callback);
 
-    input_stream.pipe(testedStream).pipe(destination_stream);
+    input_stream.pipe(testedStream).on('error', error_callback)
+    .pipe(destination_stream);
 }
 
 tape('loadJSON', function(test) {


### PR DESCRIPTION
The importer previously wasn't very strict about actually doing something about errors while reading files. It would swallow errors from failing to parse JSON, and not log anything extra when it couldn't read a file. Now it halts on both cases with error messages.

This took some changing to our little `test_stream` function, which is now getting complex enough I think we should move it to its own package soon. Additionally I had to move `t.end()` to the actual end of the callbacks from the stream, after `stdout` interception is stopped, or we can't properly track error output in the next test. I'd love to hear if anyone has ideas to make the test code cleaner, but I think it's ok.