### PR TITLE
fix: avoid error being thrown when checking for bundle index

### DIFF
--- a/src/bundleList.js
+++ b/src/bundleList.js
@@ -19,7 +19,7 @@ const bundleIndexUrl = 'https://whosonfirst.mapzen.com/bundles/index.txt';
 fs.ensureDirSync(metaDataPath);
 
 // if the bundle index file is not found, download it
-if (!fs.statSync(bundleIndexFile).isFile()) {
+if (!fs.existsSync(bundleIndexFile)) {
   fs.writeFileSync(bundleIndexFile, downloadFileSync(bundleIndexUrl));
 }
 

--- a/src/bundleList.js
+++ b/src/bundleList.js
@@ -80,9 +80,6 @@ function getBundleList(callback) {
 
     const bundles = combineBundleBuckets(roles, bundleBuckets);
 
-    console.log('Generated list of bundles:');
-    console.log(bundles);
-
     callback(null, bundles);
 
   });


### PR DESCRIPTION
`fs.statSync` throws an error when the file passed to it doesn't yet exist. `fs.existsSync` performs the job nicely.
    
https://nodejs.org/api/fs.html#fs_fs_statsync_path
https://nodejs.org/api/fs.html#fs_fs_existssync_path
