### PR TITLE
Update pelias-parallel-stream to 0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "pelias-dbclient": "2.0.0",
     "pelias-logger": "0.2.0",
     "pelias-model": "4.6.0",
-    "pelias-parallel-stream": "0.0.2",
+    "pelias-parallel-stream": "0.1.0",
     "through2": "^2.0.0",
     "through2-filter": "^2.0.0",
     "through2-map": "^3.0.0",


### PR DESCRIPTION
This was missed by greenkeeper, which appears to be happening a lot lately. Maybe it's something we should look into.