### PR TITLE
added tests for all population hierarchy fallbacks

### DIFF
--- a/src/components/extractFields.js
+++ b/src/components/extractFields.js
@@ -1,6 +1,21 @@
 var through2 = require('through2');
 var _ = require('lodash');
 
+// hierarchy in importance-descending order of population fields
+const population_hierarchy = [
+  'mz:population',
+  'wof:population',
+  'wk:population',
+  'gn:population',
+  'gn:pop',
+  'qs:pop',
+  'qs:gn_pop',
+  'zs:pop10',
+  'meso:pop',
+  'statoids:population',
+  'ne:pop_est'
+];
+
 // this function is used to verify that a US county QS altname is available
 function isUsCounty(base_record, wof_country, qs_a2_alt) {
   return 'US' === wof_country &&
@@ -11,17 +26,11 @@ function isUsCounty(base_record, wof_country, qs_a2_alt) {
 // this function favors mz:population when available, falling back to other properties.
 // see: https://github.com/whosonfirst-data/whosonfirst-data/issues/240#issuecomment-294907374
 function getPopulation( props ) {
-       if( props['mz:population'] ){          return props['mz:population']; }
-  else if( props['wof:population'] ){         return props['wof:population']; }
-  else if( props['wk:population'] ){          return props['wk:population']; }
-  else if( props['gn:population'] ){          return props['gn:population']; }
-  else if( props['gn:pop'] ){                 return props['gn:pop']; }
-  else if( props['qs:pop'] ){                 return props['qs:pop']; }
-  else if( props['qs:gn_pop'] ){              return props['qs:gn_pop']; }
-  else if( props['zs:pop10'] ){               return props['zs:pop10']; }
-  else if( props['meso:pop'] ){               return props['meso:pop']; }
-  else if( props['statoids:population'] ){    return props['statoids:population']; }
-  else if( props['ne:pop_est'] ){             return props['ne:pop_est']; }
+  // extract all the population values as numbers and find the first non-negative value
+  // returns undefined if there are no such values
+  return population_hierarchy.
+          map((field) => { return _.toNumber(props[field]); }).
+          find((val) => { return val >= 0; } );
 }
 
 function getLat(properties) {

--- a/test/components/extractFieldsTest.js
+++ b/test/components/extractFieldsTest.js
@@ -42,7 +42,6 @@ tape('readStreamComponents', function(test) {
             }
           ],
           'wof:abbreviation': 'XY',
-          'gn:population': 98765,
           'misc:photo_sum': 87654,
           ignoreField3: 'ignoreField3',
           ignoreField4: 'ignoreField4',
@@ -57,8 +56,8 @@ tape('readStreamComponents', function(test) {
         place_type: 'place type 1',
         lat: 12.121212,
         lon: 21.212121,
-        population: 98765,
         popularity: 87654,
+        population: undefined,
         abbreviation: 'XY',
         bounding_box: '-13.691314,49.909613,1.771169,60.847886',
         hierarchies: [
@@ -104,234 +103,6 @@ tape('readStreamComponents', function(test) {
 
     test_stream(input, extractFields.create(), function(err, actual) {
       t.deepEqual(actual, expected, 'stream should contain only objects with id and properties');
-      t.end();
-    });
-
-  });
-
-  test.test('gn:population should be favored over zs:pop10 when both are available', function(t) {
-    var input = [
-      {
-        id: 12345,
-        properties: {
-          'wof:name': 'name 1',
-          'wof:placetype': 'place type 1',
-          'geom:latitude': 12.121212,
-          'geom:longitude': 21.212121,
-          'geom:bbox': '-13.691314,49.909613,1.771169,60.847886',
-          'wof:abbreviation': 'XY',
-          'gn:population': 98765,
-          'zs:pop10': 87654
-        }
-      }
-    ];
-
-    var expected = [
-      {
-        id: 12345,
-        name: 'name 1',
-        place_type: 'place type 1',
-        lat: 12.121212,
-        lon: 21.212121,
-        population: 98765,
-        popularity: undefined,
-        abbreviation: 'XY',
-        bounding_box: '-13.691314,49.909613,1.771169,60.847886',
-        hierarchies: []
-      }
-    ];
-
-    test_stream(input, extractFields.create(), function(err, actual) {
-      t.deepEqual(actual, expected, 'population should not be set');
-      t.end();
-    });
-
-  });
-
-  test.test('non-0 zs:pop10 should be used for population when gn:population is not found', function(t) {
-    var input = [
-      {
-        id: 12345,
-        properties: {
-          'wof:name': 'name 1',
-          'wof:placetype': 'place type 1',
-          'geom:latitude': 12.121212,
-          'geom:longitude': 21.212121,
-          'geom:bbox': '-13.691314,49.909613,1.771169,60.847886',
-          'wof:abbreviation': 'XY',
-          'zs:pop10': 98765
-        }
-      }
-    ];
-
-    var expected = [
-      {
-        id: 12345,
-        name: 'name 1',
-        place_type: 'place type 1',
-        lat: 12.121212,
-        lon: 21.212121,
-        population: 98765,
-        popularity: undefined,
-        abbreviation: 'XY',
-        bounding_box: '-13.691314,49.909613,1.771169,60.847886',
-        hierarchies: []
-      }
-    ];
-
-    test_stream(input, extractFields.create(), function(err, actual) {
-      t.deepEqual(actual, expected, 'population should not be set');
-      t.end();
-    });
-
-  });
-
-  test.test('non-0 qs:pop should be used for population when gn:population or zs:pop10 are not found', function(t) {
-    var input = [
-      {
-        id: 12345,
-        properties: {
-          'wof:name': 'name 1',
-          'wof:placetype': 'place type 1',
-          'geom:latitude': 12.121212,
-          'geom:longitude': 21.212121,
-          'geom:bbox': '-13.691314,49.909613,1.771169,60.847886',
-          'wof:abbreviation': 'XY',
-          'qs:pop': 98765
-        }
-      }
-    ];
-
-    var expected = [
-      {
-        id: 12345,
-        name: 'name 1',
-        place_type: 'place type 1',
-        lat: 12.121212,
-        lon: 21.212121,
-        population: 98765,
-        popularity: undefined,
-        abbreviation: 'XY',
-        bounding_box: '-13.691314,49.909613,1.771169,60.847886',
-        hierarchies: []
-      }
-    ];
-
-    test_stream(input, extractFields.create(), function(err, actual) {
-      t.deepEqual(actual, expected, 'population should not be set');
-      t.end();
-    });
-
-  });
-
-  test.test('non-0 mz:population should be used for population when gn:population, zs:pop10 or qs:pop are not found', function(t) {
-    var input = [
-      {
-        id: 12345,
-        properties: {
-          'wof:name': 'name 1',
-          'wof:placetype': 'place type 1',
-          'geom:latitude': 12.121212,
-          'geom:longitude': 21.212121,
-          'geom:bbox': '-13.691314,49.909613,1.771169,60.847886',
-          'wof:abbreviation': 'XY',
-          'mz:population': 98765
-        }
-      }
-    ];
-
-    var expected = [
-      {
-        id: 12345,
-        name: 'name 1',
-        place_type: 'place type 1',
-        lat: 12.121212,
-        lon: 21.212121,
-        population: 98765,
-        popularity: undefined,
-        abbreviation: 'XY',
-        bounding_box: '-13.691314,49.909613,1.771169,60.847886',
-        hierarchies: []
-      }
-    ];
-
-    test_stream(input, extractFields.create(), function(err, actual) {
-      t.deepEqual(actual, expected, 'population should not be set');
-      t.end();
-    });
-
-  });
-
-  test.test('0 value zs:pop10 and gn:popuation not found should not set population', function(t) {
-    var input = [
-      {
-        id: 12345,
-        properties: {
-          'wof:name': 'name 1',
-          'wof:placetype': 'place type 1',
-          'geom:latitude': 12.121212,
-          'geom:longitude': 21.212121,
-          'geom:bbox': '-13.691314,49.909613,1.771169,60.847886',
-          'wof:abbreviation': 'XY',
-          'zs:pop10': 0
-        }
-      }
-    ];
-
-    var expected = [
-      {
-        id: 12345,
-        name: 'name 1',
-        place_type: 'place type 1',
-        lat: 12.121212,
-        lon: 21.212121,
-        population: undefined,
-        popularity: undefined,
-        abbreviation: 'XY',
-        bounding_box: '-13.691314,49.909613,1.771169,60.847886',
-        hierarchies: []
-      }
-    ];
-
-    test_stream(input, extractFields.create(), function(err, actual) {
-      t.deepEqual(actual, expected, 'population should not be set');
-      t.end();
-    });
-
-  });
-
-  test.test('neither gn:population nor zs:pop10 not found should not include population', function(t) {
-    var input = [
-      {
-        id: 12345,
-        properties: {
-          'wof:name': 'name 1',
-          'wof:placetype': 'place type 1',
-          'geom:latitude': 12.121212,
-          'geom:longitude': 21.212121,
-          'geom:bbox': '-13.691314,49.909613,1.771169,60.847886',
-          'wof:abbreviation': 'XY'
-        }
-      }
-    ];
-
-    var expected = [
-      {
-        id: 12345,
-        name: 'name 1',
-        place_type: 'place type 1',
-        lat: 12.121212,
-        lon: 21.212121,
-        population: undefined,
-        popularity: undefined,
-        abbreviation: 'XY',
-        bounding_box: '-13.691314,49.909613,1.771169,60.847886',
-        hierarchies: []
-      }
-    ];
-
-    test_stream(input, extractFields.create(), function(err, actual) {
-      t.deepEqual(actual, expected, 'population should not be set');
       t.end();
     });
 
@@ -726,6 +497,991 @@ tape('readStreamComponents', function(test) {
 
     test_stream(input, extractFields.create(), function(err, actual) {
       t.deepEqual(actual, expected, 'wof:abbreviation is used for abbreviation');
+      t.end();
+    });
+
+  });
+
+});
+
+tape('population fallback tests', (test) => {
+  test.test('mz:population should be used for population above all others', (t) => {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:placetype': 'country',
+          'mz:population': 10,
+          'wof:population': 11,
+          'wk:population': 12,
+          'gn:population': 13,
+          'gn:pop': 14,
+          'qs:pop': 15,
+          'qs:gn_pop': 16,
+          'zs:pop10': 17,
+          'meso:pop': 18,
+          'statoids:population': 19,
+          'ne:pop_est': 20
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'wof:name value',
+        place_type: 'country',
+        lat: undefined,
+        lon: undefined,
+        population: 10,
+        popularity: undefined,
+        bounding_box: undefined,
+        abbreviation: undefined,
+        hierarchies: []
+      }
+    ];
+
+    test_stream(input, extractFields.create(), (err, actual) => {
+      t.deepEqual(actual, expected, 'mz:population');
+      t.end();
+    });
+
+  });
+
+  test.test('wof:population should be used for population when higher-ranked aren\'t available', (t) => {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:placetype': 'country',
+          'wof:population': 11,
+          'wk:population': 12,
+          'gn:population': 13,
+          'gn:pop': 14,
+          'qs:pop': 15,
+          'qs:gn_pop': 16,
+          'zs:pop10': 17,
+          'meso:pop': 18,
+          'statoids:population': 19,
+          'ne:pop_est': 20
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'wof:name value',
+        place_type: 'country',
+        lat: undefined,
+        lon: undefined,
+        population: 11,
+        popularity: undefined,
+        bounding_box: undefined,
+        abbreviation: undefined,
+        hierarchies: []
+      }
+    ];
+
+    test_stream(input, extractFields.create(), (err, actual) => {
+      t.deepEqual(actual, expected, 'wof:population');
+      t.end();
+    });
+
+  });
+
+  test.test('wk:population should be used for population when higher-ranked aren\'t available', (t) => {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:placetype': 'country',
+          'wk:population': 12,
+          'gn:population': 13,
+          'gn:pop': 14,
+          'qs:pop': 15,
+          'qs:gn_pop': 16,
+          'zs:pop10': 17,
+          'meso:pop': 18,
+          'statoids:population': 19,
+          'ne:pop_est': 20
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'wof:name value',
+        place_type: 'country',
+        lat: undefined,
+        lon: undefined,
+        population: 12,
+        popularity: undefined,
+        bounding_box: undefined,
+        abbreviation: undefined,
+        hierarchies: []
+      }
+    ];
+
+    test_stream(input, extractFields.create(), (err, actual) => {
+      t.deepEqual(actual, expected, 'wk:population');
+      t.end();
+    });
+
+  });
+
+  test.test('gn:population should be used for population when higher-ranked aren\'t available', (t) => {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:placetype': 'country',
+          'gn:population': 13,
+          'gn:pop': 14,
+          'qs:pop': 15,
+          'qs:gn_pop': 16,
+          'zs:pop10': 17,
+          'meso:pop': 18,
+          'statoids:population': 19,
+          'ne:pop_est': 20
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'wof:name value',
+        place_type: 'country',
+        lat: undefined,
+        lon: undefined,
+        population: 13,
+        popularity: undefined,
+        bounding_box: undefined,
+        abbreviation: undefined,
+        hierarchies: []
+      }
+    ];
+
+    test_stream(input, extractFields.create(), (err, actual) => {
+      t.deepEqual(actual, expected, 'gn:population');
+      t.end();
+    });
+
+  });
+
+  test.test('gn:pop should be used for population when higher-ranked aren\'t available', (t) => {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:placetype': 'country',
+          'gn:pop': 14,
+          'qs:pop': 15,
+          'qs:gn_pop': 16,
+          'zs:pop10': 17,
+          'meso:pop': 18,
+          'statoids:population': 19,
+          'ne:pop_est': 20
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'wof:name value',
+        place_type: 'country',
+        lat: undefined,
+        lon: undefined,
+        population: 14,
+        popularity: undefined,
+        bounding_box: undefined,
+        abbreviation: undefined,
+        hierarchies: []
+      }
+    ];
+
+    test_stream(input, extractFields.create(), (err, actual) => {
+      t.deepEqual(actual, expected, 'gn:pop');
+      t.end();
+    });
+
+  });
+
+  test.test('qs:pop should be used for population when higher-ranked aren\'t available', (t) => {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:placetype': 'country',
+          'qs:pop': 15,
+          'qs:gn_pop': 16,
+          'zs:pop10': 17,
+          'meso:pop': 18,
+          'statoids:population': 19,
+          'ne:pop_est': 20
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'wof:name value',
+        place_type: 'country',
+        lat: undefined,
+        lon: undefined,
+        population: 15,
+        popularity: undefined,
+        bounding_box: undefined,
+        abbreviation: undefined,
+        hierarchies: []
+      }
+    ];
+
+    test_stream(input, extractFields.create(), (err, actual) => {
+      t.deepEqual(actual, expected, 'qs:pop');
+      t.end();
+    });
+
+  });
+
+  test.test('qs:gn_pop should be used for population when higher-ranked aren\'t available', (t) => {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:placetype': 'country',
+          'qs:gn_pop': 16,
+          'zs:pop10': 17,
+          'meso:pop': 18,
+          'statoids:population': 19,
+          'ne:pop_est': 20
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'wof:name value',
+        place_type: 'country',
+        lat: undefined,
+        lon: undefined,
+        population: 16,
+        popularity: undefined,
+        bounding_box: undefined,
+        abbreviation: undefined,
+        hierarchies: []
+      }
+    ];
+
+    test_stream(input, extractFields.create(), (err, actual) => {
+      t.deepEqual(actual, expected, 'qs:gn_pop');
+      t.end();
+    });
+
+  });
+
+  test.test('zs:pop10 should be used for population when higher-ranked aren\'t available', (t) => {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:placetype': 'country',
+          'zs:pop10': 17,
+          'meso:pop': 18,
+          'statoids:population': 19,
+          'ne:pop_est': 20
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'wof:name value',
+        place_type: 'country',
+        lat: undefined,
+        lon: undefined,
+        population: 17,
+        popularity: undefined,
+        bounding_box: undefined,
+        abbreviation: undefined,
+        hierarchies: []
+      }
+    ];
+
+    test_stream(input, extractFields.create(), (err, actual) => {
+      t.deepEqual(actual, expected, 'zs:pop10');
+      t.end();
+    });
+
+  });
+
+  test.test('meso:pop should be used for population when higher-ranked aren\'t available', (t) => {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:placetype': 'country',
+          'meso:pop': 18,
+          'statoids:population': 19,
+          'ne:pop_est': 20
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'wof:name value',
+        place_type: 'country',
+        lat: undefined,
+        lon: undefined,
+        population: 18,
+        popularity: undefined,
+        bounding_box: undefined,
+        abbreviation: undefined,
+        hierarchies: []
+      }
+    ];
+
+    test_stream(input, extractFields.create(), (err, actual) => {
+      t.deepEqual(actual, expected, 'meso:pop');
+      t.end();
+    });
+
+  });
+
+  test.test('statoids:population should be used for population when higher-ranked aren\'t available', (t) => {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:placetype': 'country',
+          'statoids:population': 19,
+          'ne:pop_est': 20
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'wof:name value',
+        place_type: 'country',
+        lat: undefined,
+        lon: undefined,
+        population: 19,
+        popularity: undefined,
+        bounding_box: undefined,
+        abbreviation: undefined,
+        hierarchies: []
+      }
+    ];
+
+    test_stream(input, extractFields.create(), (err, actual) => {
+      t.deepEqual(actual, expected, 'statoids:population');
+      t.end();
+    });
+
+  });
+
+  test.test('ne:pop_est should be used for population when higher-ranked aren\'t available', (t) => {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:placetype': 'country',
+          'ne:pop_est': 20
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'wof:name value',
+        place_type: 'country',
+        lat: undefined,
+        lon: undefined,
+        population: 20,
+        popularity: undefined,
+        bounding_box: undefined,
+        abbreviation: undefined,
+        hierarchies: []
+      }
+    ];
+
+    test_stream(input, extractFields.create(), (err, actual) => {
+      t.deepEqual(actual, expected, 'ne:pop_est');
+      t.end();
+    });
+
+  });
+
+  test.test('population should be undefined when no recognized population fields are available', (t) => {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:placetype': 'country'
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'wof:name value',
+        place_type: 'country',
+        lat: undefined,
+        lon: undefined,
+        population: undefined,
+        popularity: undefined,
+        bounding_box: undefined,
+        abbreviation: undefined,
+        hierarchies: []
+      }
+    ];
+
+    test_stream(input, extractFields.create(), (err, actual) => {
+      t.deepEqual(actual, expected, 'should be undefined');
+      t.end();
+    });
+
+  });
+
+  test.test('string population fields should be converted to integer', (t) => {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:placetype': 'country',
+          'mz:population': '10',
+          'wof:population': 11,
+          'wk:population': 12,
+          'gn:population': 13,
+          'gn:pop': 14,
+          'qs:pop': 15,
+          'qs:gn_pop': 16,
+          'zs:pop10': 17,
+          'meso:pop': 18,
+          'statoids:population': 19,
+          'ne:pop_est': 20
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'wof:name value',
+        place_type: 'country',
+        lat: undefined,
+        lon: undefined,
+        population: 10,
+        popularity: undefined,
+        bounding_box: undefined,
+        abbreviation: undefined,
+        hierarchies: []
+      }
+    ];
+
+    test_stream(input, extractFields.create(), (err, actual) => {
+      t.deepEqual(actual, expected, 'mz:population');
+      t.end();
+    });
+
+  });
+
+  test.test('unparseable-as-integer population fields should be skipped', (t) => {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:placetype': 'country',
+          'mz:population': 'this cannot be parsed an integer',
+          'wof:population': 11,
+          'wk:population': 12,
+          'gn:population': 13,
+          'gn:pop': 14,
+          'qs:pop': 15,
+          'qs:gn_pop': 16,
+          'zs:pop10': 17,
+          'meso:pop': 18,
+          'statoids:population': 19,
+          'ne:pop_est': 20
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'wof:name value',
+        place_type: 'country',
+        lat: undefined,
+        lon: undefined,
+        population: 11,
+        popularity: undefined,
+        bounding_box: undefined,
+        abbreviation: undefined,
+        hierarchies: []
+      }
+    ];
+
+    test_stream(input, extractFields.create(), (err, actual) => {
+      t.deepEqual(actual, expected, 'wof:population');
+      t.end();
+    });
+
+  });
+
+});
+
+tape('negative population fallback tests', (test) => {
+  test.test('wof:population should be used for population when higher-ranked are unavailable/negative', (t) => {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:placetype': 'country',
+          'mz:population': -1,
+          'wof:population': 11,
+          'wk:population': 12,
+          'gn:population': 13,
+          'gn:pop': 14,
+          'qs:pop': 15,
+          'qs:gn_pop': 16,
+          'zs:pop10': 17,
+          'meso:pop': 18,
+          'statoids:population': 19,
+          'ne:pop_est': 20
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'wof:name value',
+        place_type: 'country',
+        lat: undefined,
+        lon: undefined,
+        population: 11,
+        popularity: undefined,
+        bounding_box: undefined,
+        abbreviation: undefined,
+        hierarchies: []
+      }
+    ];
+
+    test_stream(input, extractFields.create(), (err, actual) => {
+      t.deepEqual(actual, expected, 'wof:population');
+      t.end();
+    });
+
+  });
+
+  test.test('wk:population should be used for population when higher-ranked are unavailable/negative', (t) => {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:placetype': 'country',
+          'wof:population': -1,
+          'wk:population': 12,
+          'gn:population': 13,
+          'gn:pop': 14,
+          'qs:pop': 15,
+          'qs:gn_pop': 16,
+          'zs:pop10': 17,
+          'meso:pop': 18,
+          'statoids:population': 19,
+          'ne:pop_est': 20
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'wof:name value',
+        place_type: 'country',
+        lat: undefined,
+        lon: undefined,
+        population: 12,
+        popularity: undefined,
+        bounding_box: undefined,
+        abbreviation: undefined,
+        hierarchies: []
+      }
+    ];
+
+    test_stream(input, extractFields.create(), (err, actual) => {
+      t.deepEqual(actual, expected, 'wk:population');
+      t.end();
+    });
+
+  });
+
+  test.test('gn:population should be used for population when higher-ranked are unavailable/negative', (t) => {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:placetype': 'country',
+          'wk:population': -1,
+          'gn:population': 13,
+          'gn:pop': 14,
+          'qs:pop': 15,
+          'qs:gn_pop': 16,
+          'zs:pop10': 17,
+          'meso:pop': 18,
+          'statoids:population': 19,
+          'ne:pop_est': 20
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'wof:name value',
+        place_type: 'country',
+        lat: undefined,
+        lon: undefined,
+        population: 13,
+        popularity: undefined,
+        bounding_box: undefined,
+        abbreviation: undefined,
+        hierarchies: []
+      }
+    ];
+
+    test_stream(input, extractFields.create(), (err, actual) => {
+      t.deepEqual(actual, expected, 'gn:population');
+      t.end();
+    });
+
+  });
+
+  test.test('gn:pop should be used for population when higher-ranked are unavailable/negative', (t) => {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:placetype': 'country',
+          'gn:population': -1,
+          'gn:pop': 14,
+          'qs:pop': 15,
+          'qs:gn_pop': 16,
+          'zs:pop10': 17,
+          'meso:pop': 18,
+          'statoids:population': 19,
+          'ne:pop_est': 20
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'wof:name value',
+        place_type: 'country',
+        lat: undefined,
+        lon: undefined,
+        population: 14,
+        popularity: undefined,
+        bounding_box: undefined,
+        abbreviation: undefined,
+        hierarchies: []
+      }
+    ];
+
+    test_stream(input, extractFields.create(), (err, actual) => {
+      t.deepEqual(actual, expected, 'gn:pop');
+      t.end();
+    });
+
+  });
+
+  test.test('qs:pop should be used for population when higher-ranked are unavailable/negative', (t) => {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:placetype': 'country',
+          'gn:pop': -1,
+          'qs:pop': 15,
+          'qs:gn_pop': 16,
+          'zs:pop10': 17,
+          'meso:pop': 18,
+          'statoids:population': 19,
+          'ne:pop_est': 20
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'wof:name value',
+        place_type: 'country',
+        lat: undefined,
+        lon: undefined,
+        population: 15,
+        popularity: undefined,
+        bounding_box: undefined,
+        abbreviation: undefined,
+        hierarchies: []
+      }
+    ];
+
+    test_stream(input, extractFields.create(), (err, actual) => {
+      t.deepEqual(actual, expected, 'qs:pop');
+      t.end();
+    });
+
+  });
+
+  test.test('qs:gn_pop should be used for population when higher-ranked are unavailable/negative', (t) => {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:placetype': 'country',
+          'qs:pop': -1,
+          'qs:gn_pop': 16,
+          'zs:pop10': 17,
+          'meso:pop': 18,
+          'statoids:population': 19,
+          'ne:pop_est': 20
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'wof:name value',
+        place_type: 'country',
+        lat: undefined,
+        lon: undefined,
+        population: 16,
+        popularity: undefined,
+        bounding_box: undefined,
+        abbreviation: undefined,
+        hierarchies: []
+      }
+    ];
+
+    test_stream(input, extractFields.create(), (err, actual) => {
+      t.deepEqual(actual, expected, 'qs:gn_pop');
+      t.end();
+    });
+
+  });
+
+  test.test('zs:pop10 should be used for population when higher-ranked are unavailable/negative', (t) => {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:placetype': 'country',
+          'qs:gn_pop': -1,
+          'zs:pop10': 17,
+          'meso:pop': 18,
+          'statoids:population': 19,
+          'ne:pop_est': 20
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'wof:name value',
+        place_type: 'country',
+        lat: undefined,
+        lon: undefined,
+        population: 17,
+        popularity: undefined,
+        bounding_box: undefined,
+        abbreviation: undefined,
+        hierarchies: []
+      }
+    ];
+
+    test_stream(input, extractFields.create(), (err, actual) => {
+      t.deepEqual(actual, expected, 'zs:pop10');
+      t.end();
+    });
+
+  });
+
+  test.test('meso:pop should be used for population when higher-ranked are unavailable/negative', (t) => {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:placetype': 'country',
+          'zs:pop10': -1,
+          'meso:pop': 18,
+          'statoids:population': 19,
+          'ne:pop_est': 20
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'wof:name value',
+        place_type: 'country',
+        lat: undefined,
+        lon: undefined,
+        population: 18,
+        popularity: undefined,
+        bounding_box: undefined,
+        abbreviation: undefined,
+        hierarchies: []
+      }
+    ];
+
+    test_stream(input, extractFields.create(), (err, actual) => {
+      t.deepEqual(actual, expected, 'meso:pop');
+      t.end();
+    });
+
+  });
+
+  test.test('statoids:population should be used for population when higher-ranked are unavailable/negative', (t) => {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:placetype': 'country',
+          'meso:pop': -1,
+          'statoids:population': 19,
+          'ne:pop_est': 20
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'wof:name value',
+        place_type: 'country',
+        lat: undefined,
+        lon: undefined,
+        population: 19,
+        popularity: undefined,
+        bounding_box: undefined,
+        abbreviation: undefined,
+        hierarchies: []
+      }
+    ];
+
+    test_stream(input, extractFields.create(), (err, actual) => {
+      t.deepEqual(actual, expected, 'statoids:population');
+      t.end();
+    });
+
+  });
+
+  test.test('ne:pop_est should be used for population when higher-ranked are unavailable/negative', (t) => {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:placetype': 'country',
+          'statoids:population': -1,
+          'ne:pop_est': 20
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'wof:name value',
+        place_type: 'country',
+        lat: undefined,
+        lon: undefined,
+        population: 20,
+        popularity: undefined,
+        bounding_box: undefined,
+        abbreviation: undefined,
+        hierarchies: []
+      }
+    ];
+
+    test_stream(input, extractFields.create(), (err, actual) => {
+      t.deepEqual(actual, expected, 'ne:pop_est');
+      t.end();
+    });
+
+  });
+
+  test.test('population should be undefined when there are no non-negative population fields', (t) => {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:placetype': 'country',
+          'ne:pop_est': -1
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'wof:name value',
+        place_type: 'country',
+        lat: undefined,
+        lon: undefined,
+        population: undefined,
+        popularity: undefined,
+        bounding_box: undefined,
+        abbreviation: undefined,
+        hierarchies: []
+      }
+    ];
+
+    test_stream(input, extractFields.create(), (err, actual) => {
+      t.deepEqual(actual, expected, 'population should be undefined');
       t.end();
     });
 


### PR DESCRIPTION
The recent addition of 7 new fields for population values was causing the WOF importer to fail in 2 scenarios:

- the field value was a [string](https://github.com/whosonfirst-data/whosonfirst-data/blob/master/data/890/449/747/890449747.geojson?short_path=82c83cf#L13)
- the field value was [negative](https://github.com/whosonfirst-data/whosonfirst-data/blob/master/data/856/322/17/85632217.geojson?short_path=49906b0#L523)

The model stipulates that the population value [must be a number and non-negative](https://github.com/pelias/model/blob/master/Document.js#L247-L249).  Records failing either criteria were causing a WOF import to crash.  Here's the error:

```
2017-04-20T02:29:37.575Z - info: [whosonfirst] Loading wof-country-latest.csv records from /Users/stephenhess/data/whosonfirst/meta/wof-country-latest.csv
exception parsing JSON in file 856/322/17/85632217.geojson: { [PeliasModelError: invalid document type, expecting: 0 or a positive number, got: -99]
  name: 'PeliasModelError',
  message: 'invalid document type, expecting: 0 or a positive number, got: -99' }
```

This PR adds functionality and tests for:
- all population fallback scenarios down to `undefined`
- converting strings to numbers
- ignoring unparseable population values
- ignoring negative population values