### PR TITLE
exposed conformsTo for filtering wof records

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,11 @@ $> npm start
 
 This project exposes a number of node streams for dealing with Who's on First data and metadata files:
 
+- `metadataStream`: streams rows from a Who's on First metadata file
 - `parseMetaFiles`: CSV parse stream configured for metadata file contents
 - `loadJSON`: parallel stream that asynchronously loads GeoJSON files
 - `recordHasIdAndProperties`: rejects Who's on First records missing id or properties
 - `isActiveRecord`: rejects records that are superseded, deprecated, or otherwise inactive
 - `isNotNullIslandRelated`: rejects [Null Island](https://whosonfirst.mapzen.com/spelunker/id/1) and other records that intersect it (currently just postal codes at 0/0)
 - `recordHasName`: rejects records without names
+- `conformsTo`: filter Who's on First records on a predicate (see lodash's [conformsTo](https://lodash.com/docs/4.17.4#conformsTo) for more information)

--- a/index.js
+++ b/index.js
@@ -5,5 +5,6 @@ module.exports = {
   loadJSON: require('./src/components/loadJSON').create,
   parseMetaFiles: require('./src/components/parseMetaFiles').create,
   recordHasIdAndProperties: require('./src/components/recordHasIdAndProperties').create,
-  recordHasName: require('./src/components/recordHasName').create
+  recordHasName: require('./src/components/recordHasName').create,
+  conformsTo: require('./src/components/conformsTo').create
 };

--- a/src/components/conformsTo.js
+++ b/src/components/conformsTo.js
@@ -1,0 +1,10 @@
+var filter = require('through2-filter');
+var _ = require('lodash');
+
+// this component isn't used by the whosonfirst importer directly but is useful
+//  for easier filtering in ad hoc scripts
+module.exports.create = function(model) {
+  return filter.obj((wofData) => {
+    return _.conformsTo(wofData, model);
+  });
+};

--- a/test/components/conformsTo.js
+++ b/test/components/conformsTo.js
@@ -1,0 +1,76 @@
+const tape = require('tape');
+const event_stream = require('event-stream');
+
+const conformsTo = require('../../src/components/conformsTo');
+
+function test_stream(input, testedStream, callback) {
+    const input_stream = event_stream.readArray(input);
+    const destination_stream = event_stream.writeArray(callback);
+
+    input_stream.pipe(testedStream).pipe(destination_stream);
+}
+
+tape('conformsTo', (test) => {
+  test.test('undefined object should return false', (t) => {
+    const model = {
+      key: (val) => {
+        return val > 0;
+      }
+    };
+
+    test_stream([undefined], conformsTo.create(model), (err, actual) => {
+      t.deepEqual(actual, [], 'should have returned false');
+      t.end();
+    });
+
+  });
+
+  test.test('object not conforming to model should return false', (t) => {
+    const input = {
+      key: 0
+    };
+
+    const model = {
+      key: (val) => {
+        return val > 0;
+      }
+    };
+
+    test_stream([input], conformsTo.create(model), (err, actual) => {
+      t.deepEqual(actual, [], 'should have returned false');
+      t.end();
+    });
+
+  });
+
+  test.test('undefined model should return true', (t) => {
+    const input = {
+      key: 0
+    };
+
+    test_stream([input], conformsTo.create(undefined), (err, actual) => {
+      t.deepEqual(actual, [input], 'should have returned true');
+      t.end();
+    });
+
+  });
+
+  test.test('object conforming to model should return true', (t) => {
+    const input = {
+      key: 0
+    };
+
+    const model = {
+      key: (val) => {
+        return val >= 0;
+      }
+    };
+
+    test_stream([input], conformsTo.create(model), (err, actual) => {
+      t.deepEqual(actual, [input], 'should have returned true');
+      t.end();
+    });
+
+  });
+
+});

--- a/test/index.js
+++ b/test/index.js
@@ -5,7 +5,7 @@ tape('index (entry point)', (test) => {
   test.test('all exposed components should be functions', (t) => {
     const index = require('../index');
 
-    t.equals(7, Object.keys(index).length);
+    t.equals(8, Object.keys(index).length);
     t.ok(_.every(index, _.isFunction), 'all exposed properties should be functions');
     t.end();
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,4 @@
+require ('./components/conformsTo.js');
 require ('./components/extractFieldsTest.js');
 require ('./components/isActiveRecordTest.js');
 require ('./components/isNotNullIslandRelated.js');


### PR DESCRIPTION
In ad hoc Who's on First data mining scripts, allows

```
  .pipe(filter.obj((o) => { return _.conformsTo(o, {
      properties: (p) => {
        return p['iso:country'] === 'US';
      }
    }); 
  }))
```

to be reduced to:

```
  .pipe(whosonfirst.conformsTo({
    properties: (p) => {
      return p['iso:country'] === 'US';
    }
  }))
```
