### PR TITLE
removed git-lfs error message, added id to error

### DIFF
--- a/src/components/loadJSON.js
+++ b/src/components/loadJSON.js
@@ -23,10 +23,7 @@ module.exports.create = function create(wofRoot, missingFilesAreFatal) {
         next(null, JSON.parse(data));
 
       } catch (parse_err) {
-        logger.error(`exception parsing JSON in file ${record.path}: ${parse_err}`);
-        logger.error('Inability to parse JSON usually means that Who\'s on First ' +
-                      'has been cloned without using git-lfs, please see instructions ' +
-                      'here: https://github.com/whosonfirst/whosonfirst-data#git-and-large-files');
+        logger.error(`exception parsing JSON for id ${record.id} in file ${record.path}: ${parse_err}`);
         next(parse_err);
 
       }

--- a/test/components/loadJSONTest.js
+++ b/test/components/loadJSONTest.js
@@ -64,13 +64,14 @@ tape('loadJSON tests', (test) => {
       fs.writeFileSync(filename, 'this is not json\n');
 
       const input = {
+        id: '17',
         path: path.basename(filename)
       };
 
       test_stream([input], loadJSON.create(temp_dir), undefined, (err, actual) => {
         temp.cleanupSync();
         t.deepEqual(actual, undefined, 'an error should be thrown');
-        t.ok(logger.isErrorMessage(/SyntaxError: Unexpected token h/), 'error output present');
+        t.ok(logger.isErrorMessage(`exception parsing JSON for id 17 in file ${input.path}: SyntaxError: Unexpected token h`));
         t.end();
       });
 

--- a/test/components/loadJSONTest.js
+++ b/test/components/loadJSONTest.js
@@ -71,7 +71,8 @@ tape('loadJSON tests', (test) => {
       test_stream([input], loadJSON.create(temp_dir), undefined, (err, actual) => {
         temp.cleanupSync();
         t.deepEqual(actual, undefined, 'an error should be thrown');
-        t.ok(logger.isErrorMessage(`exception parsing JSON for id 17 in file ${input.path}: SyntaxError: Unexpected token h`));
+        t.ok(logger.isErrorMessage(new RegExp(
+          `exception parsing JSON for id 17 in file ${path.basename(filename)}: SyntaxError: Unexpected token h.*`)));
         t.end();
       });
 


### PR DESCRIPTION
git-lfs error message is no longer applicable since `npm run download` downloads the bundles.  