### PR TITLE
switch to wof:abbreviation for dependencies

### DIFF
--- a/src/components/extractFields.js
+++ b/src/components/extractFields.js
@@ -65,12 +65,8 @@ function getName(properties) {
   }
 }
 
-function isDependencyOrCountry(placetype) {
-  return placetype === 'dependency' || placetype === 'country';
-}
-
 function getAbbreviation(properties) {
-  if (isDependencyOrCountry(properties['wof:placetype']) && properties['wof:country']) {
+  if (properties['wof:placetype'] === 'country' && properties['wof:country']) {
     return properties['wof:country'];
   }
   return properties['wof:abbreviation'];

--- a/test/components/extractFieldsTest.js
+++ b/test/components/extractFieldsTest.js
@@ -439,8 +439,8 @@ tape('readStreamComponents', function(test) {
         properties: {
           'wof:name': 'wof:name value',
           'wof:placetype': 'dependency',
-          'wof:country': 'XY',
-          'wof:abbreviation': 'YZ'
+          'wof:country': 'value from wof:country',
+          'wof:abbreviation': 'value from wof:abbreviation'
         }
       }
     ];
@@ -455,7 +455,7 @@ tape('readStreamComponents', function(test) {
         population: undefined,
         popularity: undefined,
         bounding_box: undefined,
-        abbreviation: 'XY',
+        abbreviation: 'value from wof:abbreviation',
         hierarchies: []
       }
     ];


### PR DESCRIPTION
According to whosonfirst-data/whosonfirst-data#823, `dependency` placetype records are moving abbreviations from `wof:country` to `wof:abbreviation`.  Don't merge until the bundles have been updated.  