### PR TITLE
Remove set alpha3 support

### DIFF
--- a/src/peliasDocGenerators.js
+++ b/src/peliasDocGenerators.js
@@ -32,10 +32,6 @@ function assignField(hierarchyElement, wofDoc) {
       if (iso3166.is2(hierarchyElement.abbreviation)) {
         var iso3 = iso3166.to3(hierarchyElement.abbreviation);
 
-        // only set iso3 for country records
-        if (hierarchyElement.place_type === 'country') {
-          wofDoc.setAlpha3(iso3);
-        }
         wofDoc.addParent(hierarchyElement.place_type, hierarchyElement.name, hierarchyElement.id.toString(), iso3);
 
       } else {

--- a/test/peliasDocGeneratorsTest.js
+++ b/test/peliasDocGeneratorsTest.js
@@ -188,6 +188,49 @@ tape('create', function(test) {
 
   });
 
+  test.test('country with abbreviation known as iso3 should use iso3 as abbreviation', function(t) {
+    var wofRecords = {
+      1: {
+        id: 1,
+        name: 'record name',
+        abbreviation: 'FR',
+        lat: 12.121212,
+        lon: 21.212121,
+        place_type: 'country'
+      }
+    };
+
+    // extract all the values from wofRecords to an array since that's how test_stream works
+    // sure, this could be done with map, but this is clearer
+    var input = [
+      wofRecords['1']
+    ];
+
+    var expected = [
+      new Document( 'whosonfirst', 'country', '1')
+        .setName('default', 'record name')
+        .setCentroid({ lat: 12.121212, lon: 21.212121 })
+        .addParent( 'country', 'record name', '1', 'FRA')
+    ];
+
+    var hierarchies_finder = function() {
+      return [
+        [
+          wofRecords['1']
+        ]
+      ];
+    };
+
+    var docGenerator = peliasDocGenerators.create(hierarchies_finder);
+
+    test_stream(input, docGenerator, function(err, actual) {
+      t.deepEqual(actual, expected, 'should have returned true');
+    });
+
+    t.end();
+
+  });
+
   test.test('wofRecord with bounding_box should have bounding box in Document', function(t) {
     var wofRecords = {
       1: {

--- a/test/peliasDocGeneratorsTest.js
+++ b/test/peliasDocGeneratorsTest.js
@@ -296,89 +296,6 @@ tape('create', function(test) {
 
   });
 
-  test.test('country record without abbreviation should not set alpha3', function(t) {
-    var wofRecords = {
-      1: {
-        id: 1,
-        name: 'name 1',
-        lat: 12.121212,
-        lon: 21.212121,
-        place_type: 'country'
-      }
-    };
-
-    // extract all the values from wofRecords to an array since that's how test_stream works
-    // sure, this could be done with map, but this is clearer
-    var input = [
-      wofRecords['1']
-    ];
-
-    var expected = [
-      new Document( 'whosonfirst', 'country', '1')
-        .setName('default', 'name 1')
-        .setCentroid({ lat: 12.121212, lon: 21.212121 })
-        .addParent('country', 'name 1', '1')
-    ];
-
-    var hierarchies_finder = function() {
-      return [
-        [
-          wofRecords['1']
-        ]
-      ];
-    };
-
-    var docGenerator = peliasDocGenerators.create(hierarchies_finder);
-
-    test_stream(input, docGenerator, function(err, actual) {
-      t.deepEqual(actual, expected, 'there should be no alpha3');
-      t.end();
-    });
-
-  });
-
-  test.test('country record with unknown abbreviation should not set alpha3', function(t) {
-    var wofRecords = {
-      1: {
-        id: 1,
-        name: 'name 1',
-        lat: 12.121212,
-        lon: 21.212121,
-        place_type: 'country',
-        abbreviation: 'this is not a known ISO2 country code'
-      }
-    };
-
-    // extract all the values from wofRecords to an array since that's how test_stream works
-    // sure, this could be done with map, but this is clearer
-    var input = [
-      wofRecords['1']
-    ];
-
-    var expected = [
-      new Document( 'whosonfirst', 'country', '1')
-        .setName('default', 'name 1')
-        .setCentroid({ lat: 12.121212, lon: 21.212121 })
-        .addParent('country', 'name 1', '1')
-    ];
-
-    var hierarchies_finder = function() {
-      return [
-        [
-          wofRecords['1']
-        ]
-      ];
-    };
-
-    var docGenerator = peliasDocGenerators.create(hierarchies_finder);
-
-    test_stream(input, docGenerator, function(err, actual) {
-      t.deepEqual(actual, expected, 'there should be no alpha3');
-      t.end();
-    });
-
-  });
-
   test.test('undefined population should not set population in doc', function(t) {
     var wofRecords = {
       1: {
@@ -403,7 +320,6 @@ tape('create', function(test) {
         .setName('default', 'United States')
         .setCentroid({ lat: 12.121212, lon: 21.212121 })
         .addParent('country', 'United States', '1', 'USA')
-        .setAlpha3( 'USA' )
     ];
 
     var hierarchies_finder = function() {
@@ -447,7 +363,6 @@ tape('create', function(test) {
         .setName('default', 'United States')
         .setCentroid({ lat: 12.121212, lon: 21.212121 })
         .addParent('country', 'United States', '1', 'USA')
-        .setAlpha3( 'USA' )
         .setPopulation(98765)
     ];
 
@@ -492,7 +407,6 @@ tape('create', function(test) {
         .setName('default', 'United States')
         .setCentroid({ lat: 12.121212, lon: 21.212121 })
         .addParent('country', 'United States', '1', 'USA')
-        .setAlpha3( 'USA' )
     ];
 
     var hierarchies_finder = function() {
@@ -536,7 +450,6 @@ tape('create', function(test) {
         .setName('default', 'United States')
         .setCentroid({ lat: 12.121212, lon: 21.212121 })
         .addParent('country', 'United States', '1', 'USA')
-        .setAlpha3( 'USA' )
         .setPopularity(87654)
     ];
 


### PR DESCRIPTION
In concert with pelias/model#66, remove support for setting alpha3 in documents.  