### PR TITLE
ingore timestamped bundles

### DIFF
--- a/src/bundleList.js
+++ b/src/bundleList.js
@@ -40,6 +40,10 @@ const venueRoles = [
   'venue'
 ];
 
+// the bundle index contains timestamped bundles and non tar.bz2 files.
+// this regex is used to filter the bundle list, removing invalid entries.
+// see: https://whosonfirst.mapzen.com/bundles/index.txt
+const validBundleRegex = /-latest-bundle\.tar\.bz2$/;
 
 function getPlacetypes() {
   let roles = hierarchyRoles;
@@ -127,6 +131,13 @@ function initBundleBuckets(roles) {
 function sortBundleByBuckets(roles, bundle, bundleBuckets) {
   roles.forEach((role) => {
     if (bundle.indexOf('-' + role + '-') !== -1) {
+
+      // skip invalid bundle names
+      if( !validBundleRegex.test( bundle ) ){
+        console.error( 'skip bundle', bundle );
+        return;
+      }
+
       bundleBuckets[role].push(bundle);
     }
   });

--- a/src/bundleList.js
+++ b/src/bundleList.js
@@ -134,7 +134,7 @@ function sortBundleByBuckets(roles, bundle, bundleBuckets) {
 
       // skip invalid bundle names
       if( !validBundleRegex.test( bundle ) ){
-        console.error( 'skip bundle', bundle );
+        console.error( 'info: invalid bundle name skipped', bundle );
         return;
       }
 

--- a/utils/download_data_all.js
+++ b/utils/download_data_all.js
@@ -28,7 +28,7 @@ function download(callback) {
   // 3.) move the meta file to the meta files directory
   function generateCommand(bundle, directory) {
     const csvFilename = bundle.replace(/-\d{8}T\d{6}-/, '-latest-') // support timestamped downloads
-                             .replace('-bundle.tar.bz2', '.csv');
+                              .replace('-bundle.tar.bz2', '.csv');
 
     return 'curl https://whosonfirst.mapzen.com/bundles/' + bundle + ' | tar -xj --strip-components=1 --exclude=README.txt -C ' +
       directory + ' && mv ' + path.join(directory, csvFilename) + ' ' + path.join(directory, 'meta');

--- a/utils/download_data_all.js
+++ b/utils/download_data_all.js
@@ -27,10 +27,11 @@ function download(callback) {
   //     the README file is ignored (it just would get overridden by subsequent bundles)
   // 3.) move the meta file to the meta files directory
   function generateCommand(bundle, directory) {
-    const targetPath = bundle.replace('-bundle.tar.bz2', '.csv');
+    const csvFilename = bundle.replace(/-\d{8}T\d{6}-/, '-latest-') // support timestamped downloads
+                             .replace('-bundle.tar.bz2', '.csv');
 
     return 'curl https://whosonfirst.mapzen.com/bundles/' + bundle + ' | tar -xj --strip-components=1 --exclude=README.txt -C ' +
-      directory + ' && mv ' + path.join(directory, targetPath) + ' ' + path.join(directory, 'meta');
+      directory + ' && mv ' + path.join(directory, csvFilename) + ' ' + path.join(directory, 'meta');
   }
 
   bundles.generateBundleList((err, bundlesToDownload) => {


### PR DESCRIPTION
issue reported in https://github.com/pelias/whosonfirst/issues/263

```javascript
filename = 'wof-locality-20170810T000409-bundle.tar.bz2';

filename.replace(/-\d{8}T\d{6}-/, '-latest-').replace('-bundle.tar.bz2', '.csv');
"wof-locality-latest.csv"
```

note: I also renamed the variable `targetPath` to `csvFilename` for better clarity of it's intended purpose.

resolves https://github.com/pelias/whosonfirst/issues/263