### PR TITLE
Skip Docker image builds for Greenkeeper branches

### DIFF
--- a/.circleci/docker.sh
+++ b/.circleci/docker.sh
@@ -6,6 +6,11 @@ DATE=`date +%Y-%m-%d`
 DOCKER_REPOSITORY="pelias"
 DOCKER_PROJECT="${DOCKER_REPOSITORY}/${CIRCLE_PROJECT_REPONAME}"
 
+# skip builds on greenkeeper branches
+if [[ -z "${CIRCLE_BRANCH##*greenkeeper*}" ]]; then
+	exit 0
+fi
+
 # the name of the image that represents the "branch", that is an image that will be updated over time with the git branch
 # the production branch is changed to "latest", otherwise the git branch becomes the name of the version
 if [[ "${CIRCLE_BRANCH}" == "production" ]]; then


### PR DESCRIPTION
We have found that builds for Greenkeeper branches fail because the
branch names have characters in them that are not valid in a Docker
image tag. Fortunately, we also don't really want these branches to
result in CI built Docker images anyway, so an easy workaround is to
skip building Docker images on those branches.

Connects https://github.com/pelias/dockerfiles/issues/21
Fixes https://github.com/pelias/whosonfirst/issues/279