### PR TITLE
Add more placetypes to download

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,15 @@ Currently, the supported hierarchy types are:
 - county
 - dependency
 - disputed
+- [empire](https://www.youtube.com/watch?v=-bzWSJG93P8)
 - localadmin
 - locality
 - macrocounty
 - macrohood
 - macroregion
+- marinearea
 - neighbourhood
+- ocean
 - region
 - postalcodes (optional, see configuration)
 

--- a/src/bundleList.js
+++ b/src/bundleList.js
@@ -29,7 +29,9 @@ const hierarchyRoles = [
   'locality',
   'borough',
   'macrohood',
-  'neighbourhood'
+  'neighbourhood',
+  'ocean',
+  'marinearea'
 ];
 
 const postalcodeRoles = [

--- a/src/bundleList.js
+++ b/src/bundleList.js
@@ -17,7 +17,10 @@ const peliasConfig = require( 'pelias-config' ).generate(require('../schema'));
 //
 // downloading can be done in any order, but the same order might as well be used
 const hierarchyRoles = [
+  'ocean',
+  'marinearea',
   'continent',
+  'empire',
   'country',
   'dependency',
   'disputed',
@@ -29,9 +32,7 @@ const hierarchyRoles = [
   'locality',
   'borough',
   'macrohood',
-  'neighbourhood',
-  'ocean',
-  'marinearea'
+  'neighbourhood'
 ];
 
 const postalcodeRoles = [

--- a/src/components/extractFields.js
+++ b/src/components/extractFields.js
@@ -77,6 +77,7 @@ function getAbbreviation(properties) {
 }
 
 function getHierarchies(id, properties) {
+  // if there are no hierarchies but there's a placetype, synthesize a hierarchy
   if (_.isEmpty(_.get(properties, 'wof:hierarchy')) && _.has(properties, 'wof:placetype')) {
     const hierarchy = {};
     hierarchy[properties['wof:placetype'] + '_id'] = id;
@@ -85,6 +86,7 @@ function getHierarchies(id, properties) {
 
   }
 
+  // otherwise just return the hierarchies as-is
   return _.defaultTo(properties['wof:hierarchy'], []);
 
 }
@@ -108,10 +110,7 @@ module.exports.create = function map_fields_stream() {
       population: getPopulation(json_object.properties),
       popularity: json_object.properties['misc:photo_sum'],
       hierarchies: getHierarchies(json_object.id, json_object.properties)
-      // hierarchies: _.get(json_object, 'properties.wof:hierarchy', [])
     };
-
-    // console.error(record.hierarchies);
 
     // use the QS altname if US county and available
     if (isUsCounty(record, json_object.properties['wof:country'], json_object.properties['qs:a2_alt'])) {

--- a/src/components/extractFields.js
+++ b/src/components/extractFields.js
@@ -76,6 +76,19 @@ function getAbbreviation(properties) {
   return properties['wof:abbreviation'];
 }
 
+function getHierarchies(id, properties) {
+  if (_.isEmpty(_.get(properties, 'wof:hierarchy')) && _.has(properties, 'wof:placetype')) {
+    const hierarchy = {};
+    hierarchy[properties['wof:placetype'] + '_id'] = id;
+
+    return [hierarchy];
+
+  }
+
+  return _.defaultTo(properties['wof:hierarchy'], []);
+
+}
+
 /*
   This function extracts the fields from the json_object that we're interested
   in for creating Pelias Document objects.  If there is no hierarchy then a
@@ -94,8 +107,11 @@ module.exports.create = function map_fields_stream() {
       bounding_box: getBoundingBox(json_object.properties),
       population: getPopulation(json_object.properties),
       popularity: json_object.properties['misc:photo_sum'],
-      hierarchies: _.get(json_object, 'properties.wof:hierarchy', [])
+      hierarchies: getHierarchies(json_object.id, json_object.properties)
+      // hierarchies: _.get(json_object, 'properties.wof:hierarchy', [])
     };
+
+    // console.error(record.hierarchies);
 
     // use the QS altname if US county and available
     if (isUsCounty(record, json_object.properties['wof:country'], json_object.properties['qs:a2_alt'])) {

--- a/src/peliasDocGenerators.js
+++ b/src/peliasDocGenerators.js
@@ -15,6 +15,10 @@ function assignField(hierarchyElement, wofDoc) {
     case 'county':
     case 'macrocounty':
     case 'macroregion':
+    case 'empire':
+    case 'continent':
+    case 'ocean':
+    case 'marinearea':
     case 'postalcode':
       // the above place_types don't have abbrevations (yet)
       wofDoc.addParent(hierarchyElement.place_type, hierarchyElement.name, hierarchyElement.id.toString());

--- a/test/bundleList.js
+++ b/test/bundleList.js
@@ -9,7 +9,10 @@ proxyquire.noPreserveCache();
 proxyquire.noCallThru();
 
 const ADMIN = [
+  'ocean',
+  'marinearea',
   'continent',
+  'empire',
   'country',
   'dependency',
   'disputed',
@@ -20,9 +23,7 @@ const ADMIN = [
   'localadmin',
   'locality',
   'borough',
-  'neighbourhood',
-  'ocean',
-  'marinearea'
+  'neighbourhood'
 ];
 
 const POSTALCODES = [

--- a/test/bundleList.js
+++ b/test/bundleList.js
@@ -20,7 +20,9 @@ const ADMIN = [
   'localadmin',
   'locality',
   'borough',
-  'neighbourhood'
+  'neighbourhood',
+  'ocean',
+  'marinearea'
 ];
 
 const POSTALCODES = [

--- a/test/components/extractFieldsTest.js
+++ b/test/components/extractFieldsTest.js
@@ -108,6 +108,87 @@ tape('readStreamComponents', function(test) {
 
   });
 
+  test.test('empty wof:hierarchy should synthesize from wof:placetype and id', t => {
+    const input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'name 1',
+          'wof:placetype': 'place type 1',
+          'geom:latitude': 12.121212,
+          'geom:longitude': 21.212121,
+          'geom:bbox': '-13.691314,49.909613,1.771169,60.847886',
+          'wof:hierarchy': []
+        }
+      }
+    ];
+
+    const expected = [
+      {
+        id: 12345,
+        name: 'name 1',
+        place_type: 'place type 1',
+        lat: 12.121212,
+        lon: 21.212121,
+        population: undefined,
+        popularity: undefined,
+        abbreviation: undefined,
+        bounding_box: '-13.691314,49.909613,1.771169,60.847886',
+        hierarchies: [
+          {
+            'place type 1_id': 12345
+          }
+        ]
+      }
+    ];
+
+    test_stream(input, extractFields.create(), function(err, actual) {
+      t.deepEqual(actual, expected, 'stream should contain only objects with id and properties');
+      t.end();
+    });
+
+  });
+
+  test.test('missing wof:hierarchy should synthesize from wof:placetype and id', t => {
+    const input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'name 1',
+          'wof:placetype': 'place type 1',
+          'geom:latitude': 12.121212,
+          'geom:longitude': 21.212121,
+          'geom:bbox': '-13.691314,49.909613,1.771169,60.847886',
+        }
+      }
+    ];
+
+    const expected = [
+      {
+        id: 12345,
+        name: 'name 1',
+        place_type: 'place type 1',
+        lat: 12.121212,
+        lon: 21.212121,
+        population: undefined,
+        popularity: undefined,
+        abbreviation: undefined,
+        bounding_box: '-13.691314,49.909613,1.771169,60.847886',
+        hierarchies: [
+          {
+            'place type 1_id': 12345
+          }
+        ]
+      }
+    ];
+
+    test_stream(input, extractFields.create(), function(err, actual) {
+      t.deepEqual(actual, expected, 'stream should contain only objects with id and properties');
+      t.end();
+    });
+
+  });
+
   test.test('misc:photo_sum not found should not include popularity', function(t) {
     var input = [
       {
@@ -134,7 +215,11 @@ tape('readStreamComponents', function(test) {
         popularity: undefined,
         abbreviation: 'XY',
         bounding_box: '-13.691314,49.909613,1.771169,60.847886',
-        hierarchies: []
+        hierarchies: [
+          {
+            'place type 1_id': 12345
+          }
+        ]
       }
     ];
 
@@ -172,7 +257,11 @@ tape('readStreamComponents', function(test) {
         popularity: undefined,
         bounding_box: undefined,
         abbreviation: undefined,
-        hierarchies: []
+        hierarchies: [
+          {
+            'county_id': 12345
+          }
+        ]
       }
     ];
 
@@ -208,7 +297,11 @@ tape('readStreamComponents', function(test) {
         popularity: undefined,
         bounding_box: undefined,
         abbreviation: undefined,
-        hierarchies: []
+        hierarchies: [
+          {
+            'county_id': 12345
+          }
+        ]
       }
     ];
 
@@ -245,7 +338,11 @@ tape('readStreamComponents', function(test) {
         popularity: undefined,
         bounding_box: undefined,
         abbreviation: undefined,
-        hierarchies: []
+        hierarchies: [
+          {
+            'county_id': 12345
+          }
+        ]
       }
     ];
 
@@ -421,7 +518,11 @@ tape('readStreamComponents', function(test) {
         popularity: undefined,
         bounding_box: undefined,
         abbreviation: 'XY',
-        hierarchies: []
+        hierarchies: [
+          {
+            'country_id': 12345
+          }
+        ]
       }
     ];
 
@@ -456,7 +557,11 @@ tape('readStreamComponents', function(test) {
         popularity: undefined,
         bounding_box: undefined,
         abbreviation: 'XY',
-        hierarchies: []
+        hierarchies: [
+          {
+            'dependency_id': 12345
+          }
+        ]
       }
     ];
 
@@ -491,7 +596,11 @@ tape('readStreamComponents', function(test) {
         popularity: undefined,
         bounding_box: undefined,
         abbreviation: 'YZ',
-        hierarchies: []
+        hierarchies: [
+          {
+            'country_id': 12345
+          }
+        ]
       }
     ];
 
@@ -538,7 +647,7 @@ tape('population fallback tests', (test) => {
         popularity: undefined,
         bounding_box: undefined,
         abbreviation: undefined,
-        hierarchies: []
+        hierarchies: [ { country_id: 12345 }]
       }
     ];
 
@@ -581,7 +690,7 @@ tape('population fallback tests', (test) => {
         popularity: undefined,
         bounding_box: undefined,
         abbreviation: undefined,
-        hierarchies: []
+        hierarchies: [ { country_id: 12345 }]
       }
     ];
 
@@ -623,7 +732,7 @@ tape('population fallback tests', (test) => {
         popularity: undefined,
         bounding_box: undefined,
         abbreviation: undefined,
-        hierarchies: []
+        hierarchies: [ { country_id: 12345 }]
       }
     ];
 
@@ -664,7 +773,7 @@ tape('population fallback tests', (test) => {
         popularity: undefined,
         bounding_box: undefined,
         abbreviation: undefined,
-        hierarchies: []
+        hierarchies: [ { country_id: 12345 }]
       }
     ];
 
@@ -704,7 +813,7 @@ tape('population fallback tests', (test) => {
         popularity: undefined,
         bounding_box: undefined,
         abbreviation: undefined,
-        hierarchies: []
+        hierarchies: [ { country_id: 12345 }]
       }
     ];
 
@@ -743,7 +852,7 @@ tape('population fallback tests', (test) => {
         popularity: undefined,
         bounding_box: undefined,
         abbreviation: undefined,
-        hierarchies: []
+        hierarchies: [ { country_id: 12345 }]
       }
     ];
 
@@ -781,7 +890,7 @@ tape('population fallback tests', (test) => {
         popularity: undefined,
         bounding_box: undefined,
         abbreviation: undefined,
-        hierarchies: []
+        hierarchies: [ { country_id: 12345 }]
       }
     ];
 
@@ -818,7 +927,7 @@ tape('population fallback tests', (test) => {
         popularity: undefined,
         bounding_box: undefined,
         abbreviation: undefined,
-        hierarchies: []
+        hierarchies: [ { country_id: 12345 }]
       }
     ];
 
@@ -854,7 +963,7 @@ tape('population fallback tests', (test) => {
         popularity: undefined,
         bounding_box: undefined,
         abbreviation: undefined,
-        hierarchies: []
+        hierarchies: [ { country_id: 12345 }]
       }
     ];
 
@@ -889,7 +998,7 @@ tape('population fallback tests', (test) => {
         popularity: undefined,
         bounding_box: undefined,
         abbreviation: undefined,
-        hierarchies: []
+        hierarchies: [ { country_id: 12345 }]
       }
     ];
 
@@ -923,7 +1032,7 @@ tape('population fallback tests', (test) => {
         popularity: undefined,
         bounding_box: undefined,
         abbreviation: undefined,
-        hierarchies: []
+        hierarchies: [ { country_id: 12345 }]
       }
     ];
 
@@ -956,7 +1065,7 @@ tape('population fallback tests', (test) => {
         popularity: undefined,
         bounding_box: undefined,
         abbreviation: undefined,
-        hierarchies: []
+        hierarchies: [ { country_id: 12345 }]
       }
     ];
 
@@ -1000,7 +1109,7 @@ tape('population fallback tests', (test) => {
         popularity: undefined,
         bounding_box: undefined,
         abbreviation: undefined,
-        hierarchies: []
+        hierarchies: [ { country_id: 12345 }]
       }
     ];
 
@@ -1044,7 +1153,7 @@ tape('population fallback tests', (test) => {
         popularity: undefined,
         bounding_box: undefined,
         abbreviation: undefined,
-        hierarchies: []
+        hierarchies: [ { country_id: 12345 }]
       }
     ];
 
@@ -1091,7 +1200,7 @@ tape('negative population fallback tests', (test) => {
         popularity: undefined,
         bounding_box: undefined,
         abbreviation: undefined,
-        hierarchies: []
+        hierarchies: [ { country_id: 12345 }]
       }
     ];
 
@@ -1134,7 +1243,7 @@ tape('negative population fallback tests', (test) => {
         popularity: undefined,
         bounding_box: undefined,
         abbreviation: undefined,
-        hierarchies: []
+        hierarchies: [ { country_id: 12345 }]
       }
     ];
 
@@ -1176,7 +1285,7 @@ tape('negative population fallback tests', (test) => {
         popularity: undefined,
         bounding_box: undefined,
         abbreviation: undefined,
-        hierarchies: []
+        hierarchies: [ { country_id: 12345 }]
       }
     ];
 
@@ -1217,7 +1326,7 @@ tape('negative population fallback tests', (test) => {
         popularity: undefined,
         bounding_box: undefined,
         abbreviation: undefined,
-        hierarchies: []
+        hierarchies: [ { country_id: 12345 }]
       }
     ];
 
@@ -1257,7 +1366,7 @@ tape('negative population fallback tests', (test) => {
         popularity: undefined,
         bounding_box: undefined,
         abbreviation: undefined,
-        hierarchies: []
+        hierarchies: [ { country_id: 12345 }]
       }
     ];
 
@@ -1296,7 +1405,7 @@ tape('negative population fallback tests', (test) => {
         popularity: undefined,
         bounding_box: undefined,
         abbreviation: undefined,
-        hierarchies: []
+        hierarchies: [ { country_id: 12345 }]
       }
     ];
 
@@ -1334,7 +1443,7 @@ tape('negative population fallback tests', (test) => {
         popularity: undefined,
         bounding_box: undefined,
         abbreviation: undefined,
-        hierarchies: []
+        hierarchies: [ { country_id: 12345 }]
       }
     ];
 
@@ -1371,7 +1480,7 @@ tape('negative population fallback tests', (test) => {
         popularity: undefined,
         bounding_box: undefined,
         abbreviation: undefined,
-        hierarchies: []
+        hierarchies: [ { country_id: 12345 }]
       }
     ];
 
@@ -1407,7 +1516,7 @@ tape('negative population fallback tests', (test) => {
         popularity: undefined,
         bounding_box: undefined,
         abbreviation: undefined,
-        hierarchies: []
+        hierarchies: [ { country_id: 12345 }]
       }
     ];
 
@@ -1442,7 +1551,7 @@ tape('negative population fallback tests', (test) => {
         popularity: undefined,
         bounding_box: undefined,
         abbreviation: undefined,
-        hierarchies: []
+        hierarchies: [ { country_id: 12345 }]
       }
     ];
 
@@ -1476,7 +1585,7 @@ tape('negative population fallback tests', (test) => {
         popularity: undefined,
         bounding_box: undefined,
         abbreviation: undefined,
-        hierarchies: []
+        hierarchies: [ { country_id: 12345 }]
       }
     ];
 

--- a/test/peliasDocGeneratorsTest.js
+++ b/test/peliasDocGeneratorsTest.js
@@ -13,7 +13,9 @@ function test_stream(input, testedStream, callback) {
 tape('create', function(test) {
   test.test('non-country place_types should be returned as Document with that place_type', function(t) {
     var place_types = ['neighbourhood', 'locality', 'borough', 'localadmin',
-                        'county', 'macrocounty', 'region', 'macroregion', 'dependency', 'postalcode'];
+                        'county', 'macrocounty', 'region', 'macroregion',
+                        'dependency', 'postalcode', 'ocean', 'marinearea',
+                        'continent', 'empire'];
 
     place_types.forEach(function(place_type) {
       var wofRecords = {

--- a/test/readStreamTest.js
+++ b/test/readStreamTest.js
@@ -83,7 +83,9 @@ tape('readStream', (test) => {
             bounding_box: '-13.691314,49.909613,1.771169,60.847886',
             population: 98765,
             popularity: 87654,
-            hierarchies: []
+            hierarchies: [
+              { 'place type 1_id': 123 }
+            ]
           },
           '456': {
             id: 456,
@@ -95,7 +97,9 @@ tape('readStream', (test) => {
             bounding_box: '-24.539906,34.815009,69.033946,81.85871',
             population: undefined,
             popularity: undefined,
-            hierarchies: []
+            hierarchies: [
+              { 'place type 2_id': 456 }
+            ]
           }
         });
 


### PR DESCRIPTION
Add `empire`, `ocean`, and `marinearea` to download.  Also synthesizes a hierarchy from the id and placetype when no hierarchies are in the source data.  This is useful for top-level placetypes like oceans that have no hierarchies.  Without this, the ES document would not have `ocean`, `ocean_id`, and `ocean_a` with is inconsistent with lower level placetypes like neighbourhoods where the hierarchy ensures that `neighbourhhood`, `neighbourhood_id`, and `neighbourhood_a` are in the ES documents. 