### PR TITLE
fix: deduplicate bundle list to avoid duplicate downloads

### DIFF
--- a/src/bundleList.js
+++ b/src/bundleList.js
@@ -109,7 +109,7 @@ function getBundleList(callback) {
 
   }).on('close', () => {
 
-    const bundles = combineBundleBuckets(roles, bundleBuckets);
+    const bundles = _.sortedUniq(combineBundleBuckets(roles, bundleBuckets));
 
     callback(null, bundles);
 

--- a/test/bundleList.js
+++ b/test/bundleList.js
@@ -3,6 +3,7 @@
 const tape = require('tape');
 const proxyquire = require('proxyquire');
 const fs = require('fs-extra');
+const _ = require('lodash');
 
 proxyquire.noPreserveCache();
 proxyquire.noCallThru();
@@ -136,6 +137,8 @@ tape('bundlesList tests', (test) => {
         t.assert(found, type + ' bundle(s) missing');
         return found;
       });
+
+      t.deepEquals(bundlesList, _.sortedUniq(bundlesList), 'no duplicates should exist in the bundle list');
 
       unexpected.every((type) => {
         const found = bundlesList.some((bundle) => {


### PR DESCRIPTION
For a few months now we have had constant errors when running the Who's
on First downloader. They mention problems with the `macroregion`
bundle:

```
Downloading wof-macroregion-latest-bundle.tar.bz2 bundle
done downloading wof-dependency-latest-bundle.tar.bz2 bundle
Downloading wof-macroregion-latest-bundle.tar.bz2 bundle
done downloading wof-continent-latest-bundle.tar.bz2 bundle
Downloading wof-region-latest-bundle.tar.bz2 bundle
done downloading wof-macroregion-latest-bundle.tar.bz2 bundle
Downloading wof-macrocounty-latest-bundle.tar.bz2 bundle
done downloading wof-macrocounty-latest-bundle.tar.bz2 bundle
Downloading wof-county-latest-bundle.tar.bz2 bundle
done downloading wof-macroregion-latest-bundle.tar.bz2 bundle
error downloading wof-macroregion-latest-bundle.tar.bz2 bundle: Error:
Command failed: curl
https://whosonfirst.mapzen.com/bundles/wof-macroregion-latest-bundle.tar.bz2
| tar -xj --strip-components=1 --exclude=README.txt -C
/home/julian/data/wof/ && mv
/home/julian/data/wof/wof-macroregion-latest.csv
/home/julian/data/wof/meta
  % Total    % Received % Xferd  Average Speed   Time    Time     Time
  % Current
                                 Dload  Upload   Total   Spent    Left
Speed
100 18.0M  100 18.0M    0     0  2133k      0  0:00:08  0:00:08 --:--:--
2662k
mv: cannot stat '/home/julian/data/wof/wof-macroregion-latest.csv': No
such file or directory

  % Total    % Received % Xferd  Average Speed   Time    Time     Time
  % Current
                                 Dload  Upload   Total   Spent    Left
Speed
100 18.0M  100 18.0M    0     0  2133k      0  0:00:08  0:00:08 --:--:--
2662k
mv: cannot stat '/home/julian/data/wof/wof-macroregion-latest.csv': No
such file or directory
```

However, when the command listed in the error is tried manually, it
always succeeds.

Careful examination of the log shows that we were trying to download the
macroregion bundle twice, and the two downloads conflict with each other
(fortunately, it appears the download itself succeeds).

It turns out the source of the duplication is in the Who's on First
bundle list, so by deduplicating the bundle list just before sending it
to the downloader code, we can ensure that even if there are duplicates
in the Who's on First published bundle list, the downloader does the
right thing.