### PR TITLE
Add support for Node.js 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ notifications:
 node_js:
   - 4
   - 6
+  - 8
 matrix:
   fast_finish: true
 env:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ pelias-whosonfirst is a tool used for importing [Who's On First data](https://wh
 
 ## Requirements
 
-Node.js 4 or 6 (the latest in the 4 series is currently recommended).
+Node.js 4, 6, or 8 (the latest in the 4 series is currently recommended).
 
 ## Types
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pelias-whosonfirst",
   "version": "0.0.0-semantic-release",
   "engines": {
-    "node": ">=4.0.0 <8.0.0"
+    "node": ">=4.0.0"
   },
   "description": "Importer for Who's on First",
   "main": "index.js",

--- a/src/components/parseMetaFiles.js
+++ b/src/components/parseMetaFiles.js
@@ -1,4 +1,4 @@
-const parse = require('csv-stream');
+const csv_stream = require('csv-stream');
 const EOL = require('os').EOL;
 
 // this CSV parser assumes that:
@@ -12,5 +12,11 @@ const options = {
 };
 
 module.exports.create = function create() {
-  return parse.createStream(options);
+  const csv_parse_stream = csv_stream.createStream(options);
+
+  // override default encoding which is not set properly for Node.js 8
+  // see https://github.com/lbdremy/node-csv-stream/issues/13
+  csv_parse_stream._encoding = undefined;
+
+  return csv_parse_stream;
 };


### PR DESCRIPTION
Node.js 8 support in this repository was held back only because of an incompatibility in the [csv-stream](https://www.npmjs.com/package/csv-stream) module. That module is probably abandoned, but fortunately there's an [easy workaround](https://github.com/lbdremy/node-csv-stream/issues/13) that doesn't require any changes in the module.