### PR TITLE
Correctly filter for region-specific bundles

### DIFF
--- a/src/bundleList.js
+++ b/src/bundleList.js
@@ -131,7 +131,7 @@ function sortBundleByBuckets(roles, bundle, bundleBuckets) {
   roles.forEach((role) => {
     // search for the occurrence of role-latest-bundle, like region-latest-bundle
     // timestamped bundles should be skipped as they are of the format role-timestamp-bundle
-    const validBundleRegex = new RegExp(`${role}-(\\w{2}-)?latest`);
+    const validBundleRegex = new RegExp(`${role}-[\\w-]*latest`);
     if (validBundleRegex.test( bundle ) ) {
       bundleBuckets[role].push(bundle);
     }

--- a/test/bundleList.js
+++ b/test/bundleList.js
@@ -68,6 +68,30 @@ tape('bundlesList tests', (test) => {
     });
   });
 
+  test.test('region venue bundles', (t) => {
+    const config = {
+      generate: () => {
+        return {
+          imports: {
+            whosonfirst: {
+              datapath: 'foo',
+              importVenues: true,
+              importPostalcodes: true
+            }
+          }
+        };
+      }
+    };
+
+    const bundles = proxyquire('../src/bundleList', { 'pelias-config': config });
+
+    bundles.generateBundleList((err, bundlesList) => {
+      t.assert(bundlesList.includes('wof-venue-us-ca-latest-bundle.tar.bz2'), 'venue bundle for regions are included');
+      fs.removeSync('foo');
+      t.end();
+    });
+  });
+
   test.test('admin only bundles', (t) => {
 
     const config = {


### PR DESCRIPTION
Our previous regular expression for filtering venue bundles was too strict, and would filter out bundles that are specific to a single region within a country (most bundles are for an entire country).

In particular, venue bundles are split up for each US state, so we were missing quite a few important venues.

Connects https://github.com/pelias/whosonfirst/issues/94