### PR TITLE
extract regional data from wof sqlite db

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM pelias/baseimage
 
 # downloader apt dependencies
 # note: this is done in one command in order to keep down the size of intermediate containers
-RUN apt-get update && apt-get install -y bzip2 unzip && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y autoconf automake libtool pkg-config python bzip2 unzip && rm -rf /var/lib/apt/lists/*
 
 # change working dir
 ENV WORKDIR /code/pelias/whosonfirst

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The following configuration options are supported by this importer.
 | `imports.whosonfirst.importPostalcodes` | no | false | set to `true` to include postalcodes in the data download and import process |
 | `imports.whosonfirst.importVenues` | no | false | set to `true` to include venues in the data download and import process |
 | `imports.whosonfirst.importPlace` | no | | set to a WOF id (number or string) indicating the region of interest, only data pertaining to that place shall be downloaded. Use the WOF [spelunker tool](https://spelunker.whosonfirst.org/) search for an ID of a place. |
-| `imports.whosonfirst.missingFilesAreFatal` | no | false | set to `true` for missing files from [Who's on First bundles](https://whosonfirst.mapzen.com/bundles/) to stop the import process |
+| `imports.whosonfirst.missingFilesAreFatal` | no | false | set to `true` for missing files from [Who's on First bundles](https://dist.whosonfirst.org/bundles/) to stop the import process |
 
 ## Downloading the Data
 
@@ -109,6 +109,6 @@ This project exposes a number of node streams for dealing with Who's on First da
 - `loadJSON`: parallel stream that asynchronously loads GeoJSON files
 - `recordHasIdAndProperties`: rejects Who's on First records missing id or properties
 - `isActiveRecord`: rejects records that are superseded, deprecated, or otherwise inactive
-- `isNotNullIslandRelated`: rejects [Null Island](https://whosonfirst.mapzen.com/spelunker/id/1) and other records that intersect it (currently just postal codes at 0/0)
+- `isNotNullIslandRelated`: rejects [Null Island](https://spelunker.whosonfirst.org/id/1) and other records that intersect it (currently just postal codes at 0/0)
 - `recordHasName`: rejects records without names
 - `conformsTo`: filter Who's on First records on a predicate (see lodash's [conformsTo](https://lodash.com/docs/4.17.4#conformsTo) for more information)

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "homepage": "https://github.com/pelias/whosonfirst#readme",
   "dependencies": {
     "async": "^2.5.0",
+    "better-sqlite3": "^4.1.0",
     "combined-stream": "^1.0.5",
     "csv-stream": "^0.1.3",
     "csv-string": "^3.1.2",

--- a/schema.js
+++ b/schema.js
@@ -7,10 +7,11 @@ const Joi = require('joi');
 // optional:
 // * imports.whosonfirst.importVenues (boolean) (default: false)
 // * imports.whosonfirst.importPostalcodes (boolean) (default: false)
+// * imports.whosonfirst.importConstituencies (boolean) (default: false)
+// * imports.whosonfirst.importIntersections (boolean) (default: false)
 // * imports.whosonfirst.importPlace (string) (default: none)
-// * imports.whosonfirst.api_key (string) (default: none)
+// * imports.whosonfirst.api_key (string) (default: none) DEPRECATED
 // * imports.whosonfirst.missingFilesAreFatal (boolean) (default: false)
-// * imports.whosonfirst.sqliteDatabases array of objects containing filename (optional)
 
 module.exports = Joi.object().keys({
   imports: Joi.object().keys({
@@ -20,10 +21,9 @@ module.exports = Joi.object().keys({
       api_key: Joi.string(),
       importVenues: Joi.boolean().default(false).truthy('yes').falsy('no').insensitive(true),
       importPostalcodes: Joi.boolean().default(false).truthy('yes').falsy('no').insensitive(true),
-      missingFilesAreFatal: Joi.boolean().default(false).truthy('yes').falsy('no').insensitive(true),
-      sqliteDatabases: Joi.array().items(Joi.object().keys({
-        filename: Joi.string()
-      }).requiredKeys('filename').unknown(true)),
+      importConstituencies: Joi.boolean().default(false).truthy('yes').falsy('no').insensitive(true),
+      importIntersections: Joi.boolean().default(false).truthy('yes').falsy('no').insensitive(true),
+      missingFilesAreFatal: Joi.boolean().default(false).truthy('yes').falsy('no').insensitive(true)
     }).requiredKeys('datapath').unknown(false)
   }).requiredKeys('whosonfirst').unknown(true)
 }).requiredKeys('imports').unknown(true);

--- a/schema.js
+++ b/schema.js
@@ -9,7 +9,7 @@ const Joi = require('joi');
 // * imports.whosonfirst.importPostalcodes (boolean) (default: false)
 // * imports.whosonfirst.importConstituencies (boolean) (default: false)
 // * imports.whosonfirst.importIntersections (boolean) (default: false)
-// * imports.whosonfirst.importPlace (string) (default: none)
+// * imports.whosonfirst.importPlace (integer OR array[integer]) (default: none)
 // * imports.whosonfirst.api_key (string) (default: none) DEPRECATED
 // * imports.whosonfirst.missingFilesAreFatal (boolean) (default: false)
 
@@ -17,7 +17,10 @@ module.exports = Joi.object().keys({
   imports: Joi.object().keys({
     whosonfirst: Joi.object().keys({
       datapath: Joi.string(),
-      importPlace: Joi.number().integer(),
+      importPlace: [
+        Joi.number().integer(),
+        Joi.array().items(Joi.number().integer())
+      ],
       api_key: Joi.string(),
       importVenues: Joi.boolean().default(false).truthy('yes').falsy('no').insensitive(true),
       importPostalcodes: Joi.boolean().default(false).truthy('yes').falsy('no').insensitive(true),

--- a/schema.js
+++ b/schema.js
@@ -10,6 +10,7 @@ const Joi = require('joi');
 // * imports.whosonfirst.importPlace (string) (default: none)
 // * imports.whosonfirst.api_key (string) (default: none)
 // * imports.whosonfirst.missingFilesAreFatal (boolean) (default: false)
+// * imports.whosonfirst.sqliteDatabases array of objects containing filename (optional)
 
 module.exports = Joi.object().keys({
   imports: Joi.object().keys({
@@ -20,7 +21,7 @@ module.exports = Joi.object().keys({
       importVenues: Joi.boolean().default(false).truthy('yes').falsy('no').insensitive(true),
       importPostalcodes: Joi.boolean().default(false).truthy('yes').falsy('no').insensitive(true),
       missingFilesAreFatal: Joi.boolean().default(false).truthy('yes').falsy('no').insensitive(true),
-      sqlite_files: Joi.array().items(Joi.object().keys({
+      sqliteDatabases: Joi.array().items(Joi.object().keys({
         filename: Joi.string()
       }).requiredKeys('filename').unknown(true)),
     }).requiredKeys('datapath').unknown(false)

--- a/schema.js
+++ b/schema.js
@@ -19,7 +19,10 @@ module.exports = Joi.object().keys({
       api_key: Joi.string(),
       importVenues: Joi.boolean().default(false).truthy('yes').falsy('no').insensitive(true),
       importPostalcodes: Joi.boolean().default(false).truthy('yes').falsy('no').insensitive(true),
-      missingFilesAreFatal: Joi.boolean().default(false).truthy('yes').falsy('no').insensitive(true)
+      missingFilesAreFatal: Joi.boolean().default(false).truthy('yes').falsy('no').insensitive(true),
+      sqlite_files: Joi.array().items(Joi.object().keys({
+        filename: Joi.string()
+      }).requiredKeys('filename').unknown(true)),
     }).requiredKeys('datapath').unknown(false)
   }).requiredKeys('whosonfirst').unknown(true)
 }).requiredKeys('imports').unknown(true);

--- a/src/bundleList.js
+++ b/src/bundleList.js
@@ -62,7 +62,7 @@ function getPlacetypes() {
 
 function ensureBundleIndexExists(metaDataPath) {
   const bundleIndexFile = path.join(metaDataPath, 'whosonfirst_bundle_index.txt');
-  const bundleIndexUrl = 'https://whosonfirst.mapzen.com/bundles/index.txt';
+  const bundleIndexUrl = 'https://dist.whosonfirst.org/bundles/index.txt';
 
   //ensure required directory structure exists
   fs.ensureDirSync(metaDataPath);

--- a/src/components/loadJSON.js
+++ b/src/components/loadJSON.js
@@ -12,7 +12,7 @@ module.exports.create = function create(wofRoot, missingFilesAreFatal) {
 
     if (!record.path || record.path === 'path') {
       // we can generate the record path if column not present in metadata
-      record.path = wofIdToPath(record.id).concat(record.id+'.json').join(path.sep);
+      record.path = wofIdToPath(record.id).concat(record.id+'.geojson').join(path.sep);
 
       // failed to infer the data disk path
       if(!path.length){

--- a/src/components/loadJSON.js
+++ b/src/components/loadJSON.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const fs = require('fs');
 const parallelStream = require('pelias-parallel-stream');
+const wofIdToPath = require('../wofIdToPath');
 
 const maxInFlight = 10;
 
@@ -10,8 +11,14 @@ module.exports.create = function create(wofRoot, missingFilesAreFatal) {
   return parallelStream(maxInFlight, function(record, enc, next) {
 
     if (!record.path || record.path === 'path') {
-      logger.warn('WOF record has no path', record);
-      return next();
+      // we can generate the record path if column not present in metadata
+      record.path = wofIdToPath(record.id).join(path.sep);
+
+      // failed to infer the data disk path
+      if(!path.length){
+        logger.warn('WOF record has no path', record);
+        return next();
+      }
     }
 
     const full_file_path = path.join(wofRoot, 'data', record.path);

--- a/src/components/loadJSON.js
+++ b/src/components/loadJSON.js
@@ -12,7 +12,7 @@ module.exports.create = function create(wofRoot, missingFilesAreFatal) {
 
     if (!record.path || record.path === 'path') {
       // we can generate the record path if column not present in metadata
-      record.path = wofIdToPath(record.id).join(path.sep);
+      record.path = wofIdToPath(record.id).concat(record.id+'.json').join(path.sep);
 
       // failed to infer the data disk path
       if(!path.length){

--- a/src/wofIdToPath.js
+++ b/src/wofIdToPath.js
@@ -1,0 +1,14 @@
+
+// convert wofid integer to array of path components
+function wofIdToPath( id ){
+  let strId = id.toString();
+  let parts = [];
+  while( strId.length ){
+    let part = strId.substr(0, 3);
+    parts.push(part);
+    strId = strId.substr(3);
+  }
+  return parts;
+}
+
+module.exports = wofIdToPath;

--- a/src/wofIdToPath.js
+++ b/src/wofIdToPath.js
@@ -1,3 +1,4 @@
+'use strict';
 
 // convert wofid integer to array of path components
 function wofIdToPath( id ){

--- a/test/components/wofIdToPath.js
+++ b/test/components/wofIdToPath.js
@@ -1,0 +1,41 @@
+const tape = require('tape');
+const wofIdToPath = require('../../src/wofIdToPath');
+
+tape('wofIdToPath', (t) => {
+  t.test('invalid path', (t) => {
+    t.deepEqual(wofIdToPath(''), [], 'should be empty');
+    t.end();
+  });
+  t.test('9 digit string', (t) => {
+    t.deepEqual(wofIdToPath('123456789'), ['123', '456', '789']);
+    t.end();
+  });
+  t.test('9 digit integer', (t) => {
+    t.deepEqual(wofIdToPath(123456789), ['123', '456', '789']);
+    t.end();
+  });
+  t.test('10 digit string', (t) => {
+    t.deepEqual(wofIdToPath('1234567890'), ['123', '456', '789', '0']);
+    t.end();
+  });
+  t.test('10 digit integer', (t) => {
+    t.deepEqual(wofIdToPath(1234567890), ['123', '456', '789', '0']);
+    t.end();
+  });
+  t.test('1 digit string', (t) => {
+    t.deepEqual(wofIdToPath('1'), ['1']);
+    t.end();
+  });
+  t.test('1 digit integer', (t) => {
+    t.deepEqual(wofIdToPath(1), ['1']);
+    t.end();
+  });
+  t.test('0 string', (t) => {
+    t.deepEqual(wofIdToPath('0'), ['0']);
+    t.end();
+  });
+  t.test('0 integer', (t) => {
+    t.deepEqual(wofIdToPath(0), ['0']);
+    t.end();
+  });
+});

--- a/test/schema.js
+++ b/test/schema.js
@@ -258,6 +258,23 @@ tape('battery of importPlace tests', test => {
 
   });
 
+  test.test('array of strings importPlace should be cast as number', t => {
+    const config = {
+      imports: {
+        whosonfirst: {
+          datapath: '/path/to/data',
+          importPlace: ['123','456']
+        }
+      }
+    };
+
+    const validated = Joi.validate(config, schema);
+
+    t.deepEquals(validated.value.imports.whosonfirst.importPlace, [123,456]);
+    t.end();
+
+  });
+
   test.test('non-string importPlace should remain as number', t => {
     const config = {
       imports: {
@@ -275,8 +292,25 @@ tape('battery of importPlace tests', test => {
 
   });
 
+  test.test('array of non-string importPlace should remain as number', t => {
+    const config = {
+      imports: {
+        whosonfirst: {
+          datapath: '/path/to/data',
+          importPlace: [123, 456]
+        }
+      }
+    };
+
+    const validated = Joi.validate(config, schema);
+
+    t.deepEquals(validated.value.imports.whosonfirst.importPlace, [123, 456]);
+    t.end();
+
+  });
+
   test.test('non-string/integer importPlace values should not validate', t => {
-    [null, false, {}, [], 'string'].forEach((value) => {
+    [null, false, {}, 'string'].forEach((value) => {
       const config = {
         imports: {
           whosonfirst: {
@@ -288,8 +322,32 @@ tape('battery of importPlace tests', test => {
 
       const result = Joi.validate(config, schema);
 
-      t.equals(result.error.details.length, 1);
+      t.equals(result.error.details.length, 2);
       t.equals(result.error.details[0].message, '"importPlace" must be a number');
+      t.equals(result.error.details[1].message, '"importPlace" must be an array');
+
+    });
+
+    t.end();
+
+  });
+
+  test.test('arra of non-string/integer importPlace values should not validate', t => {
+    [null, false, {}, 'string'].forEach((value) => {
+      const config = {
+        imports: {
+          whosonfirst: {
+            datapath: '/path/to/data',
+            importPlace: [value]
+          }
+        }
+      };
+
+      const result = Joi.validate(config, schema);
+
+      t.equals(result.error.details.length, 2);
+      t.equals(result.error.details[0].message, '"importPlace" must be a number');
+      t.equals(result.error.details[1].message, '"0" must be a number');
 
     });
 
@@ -309,8 +367,28 @@ tape('battery of importPlace tests', test => {
 
     const result = Joi.validate(config, schema);
 
-    t.equals(result.error.details.length, 1);
+    t.equals(result.error.details.length, 2);
     t.equals(result.error.details[0].message, '"importPlace" must be an integer');
+    t.equals(result.error.details[1].message, '"importPlace" must be an array');
+    t.end();
+
+  });
+
+  test.test('array of non-integer importPlace values should not validate', t => {
+    const config = {
+      imports: {
+        whosonfirst: {
+          datapath: '/path/to/data',
+          importPlace: [17.3, 18.2]
+        }
+      }
+    };
+
+    const result = Joi.validate(config, schema);
+
+    t.equals(result.error.details.length, 2);
+    t.equals(result.error.details[0].message, '"importPlace" must be a number');
+    t.equals(result.error.details[1].message, '"0" must be an integer');
     t.end();
 
   });

--- a/test/test.js
+++ b/test/test.js
@@ -7,6 +7,7 @@ require ('./components/metadataStream.js');
 require ('./components/parseMetaFiles.js');
 require ('./components/recordHasIdAndPropertiesTest.js');
 require ('./components/recordHasNameTest.js');
+require ('./components/wofIdToPath.js');
 require ('./hierarchyFinderTest.js');
 require ('./importStreamTest.js');
 require ('./peliasDocGeneratorsTest.js');

--- a/utils/download_data.js
+++ b/utils/download_data.js
@@ -4,8 +4,37 @@ function on_done() {
   console.log('All done!');
 }
 
-if (config.imports.whosonfirst.importPlace) {
-  require('./download_data_filtered/index').download(on_done);
+if (config.imports.whosonfirst.sqliteDatabases) {
+  require('./sqlite_download').download(on_done);
+}
+else if (config.imports.whosonfirst.importPlace) {
+  console.error(`
+    The whosonfirst API is currently offline (due to the shutdown of mapzen).
+
+    We recommend updating your ~/pelias.json to use the new sqlite extract scripts instead.
+    The sqlite databases are the preferred method of sourcing regional extracts going forward.
+
+    Visit: https://dist.whosonfirst.org/sqlite/
+    Select the database file(s) you would like to use and add them to your ~/pelias.json
+    You may then rerun this script, the databases will be downloaded/updated for you.
+
+    example config section:
+
+    "whosonfirst": {
+      "datapath": "/tmp",
+      "importVenues": false,
+      "importPostalcodes": true,
+      "importPlace": "101715829",
+      "sqliteDatabases": [
+        { "filename": "whosonfirst-data-latest.db" },
+        { "filename": "whosonfirst-data-postalcode-us-latest.db" }
+      ]
+    }
+
+    see: https://github.com/pelias/whosonfirst/pull/324 for more info`
+  );
+  process.exit(1);
+  // require('./download_data_filtered/index').download(on_done);
 }
 else {
   require('./download_data_all').download(on_done);

--- a/utils/download_data.js
+++ b/utils/download_data.js
@@ -24,14 +24,14 @@ if( config.importPlace ) {
           if( 'us' === parts[0] ){
             databases.push(`whosonfirst-data-venue-${subdivision}-latest.db`);
           } else {
-            console.error(`whosonfirst-data-venue-${parts[0]}-latest.db`);
+            databases.push(`whosonfirst-data-venue-${parts[0]}-latest.db`);
           }
         }
         if( true === config.importIntersections ){
           if( 'us' === parts[0] ){
             databases.push(`whosonfirst-data-intersection-${subdivision}-latest.db`);
           } else {
-            console.error(`whosonfirst-data-intersection-${parts[0]}-latest.db`);
+            databases.push(`whosonfirst-data-intersection-${parts[0]}-latest.db`);
           }
         }
       }

--- a/utils/download_data.js
+++ b/utils/download_data.js
@@ -5,7 +5,9 @@ function on_done() {
 }
 
 if (config.imports.whosonfirst.sqliteDatabases) {
-  require('./sqlite_download').download(on_done);
+  require('./sqlite_download').download(() => {
+    require('./sqlite_extract_data').extract({ unlink: true }, on_done);
+  });
 }
 else if (config.imports.whosonfirst.importPlace) {
   console.error(`

--- a/utils/download_data.js
+++ b/utils/download_data.js
@@ -19,6 +19,7 @@ if( config.importPlace ) {
     const subdivisions = findSubdivisions( mainDataDB );
     subdivisions.forEach( subdivision => {
       let parts = subdivision.split('-');
+      if( 'xx' === parts[0] ){ return; } // ignore 'xx' unspecified subdivisions
       if( parts.length > 1 ){
         if( true === config.importVenues ){
           if( 'us' === parts[0] ){

--- a/utils/download_data.js
+++ b/utils/download_data.js
@@ -46,6 +46,9 @@ if( config.importPlace ) {
       }
     });
 
+    // dedupe array
+    databases = databases.filter((item, pos) => databases.indexOf(item) === pos);
+
     // download additonal database files
     download({ databases: databases }, () => {
 

--- a/utils/download_data_all.js
+++ b/utils/download_data_all.js
@@ -30,7 +30,7 @@ function download(callback) {
     const csvFilename = bundle.replace(/-\d{8}T\d{6}-/, '-latest-') // support timestamped downloads
                               .replace('-bundle.tar.bz2', '.csv');
 
-    return 'curl https://whosonfirst.mapzen.com/bundles/' + bundle + ' | tar -xj --strip-components=1 --exclude=README.txt -C ' +
+    return 'curl https://dist.whosonfirst.org/bundles/' + bundle + ' | tar -xj --strip-components=1 --exclude=README.txt -C ' +
       directory + ' && mv ' + path.join(directory, csvFilename) + ' ' + path.join(directory, 'meta');
   }
 

--- a/utils/download_data_filtered/downloadPlaces.js
+++ b/utils/download_data_filtered/downloadPlaces.js
@@ -7,6 +7,7 @@ const async = require('async');
 const logger = require('pelias-logger').get('download_data_filtered');
 const parallelStream = require('pelias-parallel-stream');
 const streamArray = require('stream-array');
+const wofIdToPath = require('../../src/wofIdToPath');
 
 const maxInFlight = 4;
 
@@ -54,15 +55,7 @@ function downloadById(params, callback) {
     return onError(`Invalid ID: ${placeId}`, new Error(`Invalid ID`), callback);
   }
 
-  let strId = placeId.toString();
-  let subPath = [];
-
-  while (strId.length){
-    let part = strId.substr(0, 3);
-    subPath.push(part);
-    strId = strId.substr(3);
-  }
-
+  let subPath = wofIdToPath(placeId);
   const filename = `${placeId}.geojson`;
   const sourceUrl = `${_defaultHost}/data/${subPath.join('/')}/${filename}`;
   const targetDirFull = path.join(targetDir, subPath.join(path.sep));
@@ -93,4 +86,3 @@ function onError(error, message, callback) {
 }
 
 module.exports.downloadPlaces = downloadPlaces;
-

--- a/utils/download_data_filtered/index.js
+++ b/utils/download_data_filtered/index.js
@@ -16,6 +16,15 @@ const downloadPlaces = require('./downloadPlaces').downloadPlaces;
 // const Berlin = '101748799';
 
 function download(callback) {
+
+  // array support for 'importPlace' was added after this downloader was written.
+  // backwards compatibility support since the schema validation changed to support arrays.
+  if( Array.isArray( config.imports.whosonfirst.importPlace ) ){
+    console.error('this download method only supports a single entry for whosonfirst.importPlace');
+    config.imports.whosonfirst.importPlace = config.imports.whosonfirst.importPlace[0];
+    console.error('only using the first value in the array:', config.imports.whosonfirst.importPlace );
+  }
+
   const context = {
     apiKey: config.imports.whosonfirst.api_key,
     // path to data directory where the data will be downloaded to, it will be created if doesn't exist

--- a/utils/sqlite_common.js
+++ b/utils/sqlite_common.js
@@ -2,37 +2,6 @@
 const fs = require('fs');
 const path = require('path');
 
-module.exports.validateConfig = function validateConfig( config, mustExist ){
-
-  // ensure sqliteDatabases array is specified in config
-  if( !Array.isArray( config.sqliteDatabases ) || !config.sqliteDatabases.length ){
-    console.error('you must specify the imports.whosonfirst.sqliteDatabases array in your pelias.json');
-    process.exit(1);
-  }
-
-  // ensure importPlace is specified in config
-  if( !config.hasOwnProperty('importPlace') ){
-    console.error('you must specify a wofid as imports.whosonfirst.importPlace in your pelias.json');
-    process.exit(1);
-  }
-
-  // ensure entries are valid
-  config.sqliteDatabases = config.sqliteDatabases.map(entry => {
-    if( entry.filename !== path.basename( entry.filename ) ){
-      throw new Error( 'config: sqlite filename should not include path: ' + entry.filename );
-    }
-    if( !entry.path ){ entry.path = config.datapath; }
-    if( !fs.existsSync( entry.path ) ){
-      throw new Error( 'config: sqlite path not found: ' + entry.path );
-    }
-    let absPath = path.join( entry.path, entry.filename );
-    if( true === mustExist && !fs.existsSync( absPath ) ){
-      throw new Error( 'config: sqlite file not found: ' + absPath );
-    }
-    return entry;
-  });
-};
-
 // handler for all metatdata streams
 module.exports.MetaDataFiles = function MetaDataFiles( metaDir ){
   let streams = {};

--- a/utils/sqlite_common.js
+++ b/utils/sqlite_common.js
@@ -10,6 +10,12 @@ module.exports.validateConfig = function validateConfig( config, mustExist ){
     process.exit(1);
   }
 
+  // ensure importPlace is specified in config
+  if( !config.hasOwnProperty('importPlace') ){
+    console.error('you must specify a wofid as imports.whosonfirst.importPlace in your pelias.json');
+    process.exit(1);
+  }
+
   // ensure entries are valid
   config.sqliteDatabases = config.sqliteDatabases.map(entry => {
     if( entry.filename !== path.basename( entry.filename ) ){

--- a/utils/sqlite_common.js
+++ b/utils/sqlite_common.js
@@ -1,0 +1,65 @@
+
+const fs = require('fs');
+const path = require('path');
+
+module.exports.validateConfig = function validateConfig( config, mustExist ){
+
+  // ensure sqliteDatabases array is specified in config
+  if( !Array.isArray( config.sqliteDatabases ) || !config.sqliteDatabases.length ){
+    console.error('you must specify the imports.whosonfirst.sqliteDatabases array in your pelias.json');
+    process.exit(1);
+  }
+
+  // ensure entries are valid
+  config.sqliteDatabases = config.sqliteDatabases.map(entry => {
+    if( entry.filename !== path.basename( entry.filename ) ){
+      throw new Error( 'config: sqlite filename should not include path: ' + entry.filename );
+    }
+    if( !entry.path ){ entry.path = config.datapath; }
+    if( !fs.existsSync( entry.path ) ){
+      throw new Error( 'config: sqlite path not found: ' + entry.path );
+    }
+    let absPath = path.join( entry.path, entry.filename );
+    if( true === mustExist && !fs.existsSync( absPath ) ){
+      throw new Error( 'config: sqlite file not found: ' + absPath );
+    }
+    return entry;
+  });
+};
+
+// handler for all metatdata streams
+module.exports.MetaDataFiles = function MetaDataFiles( metaDir ){
+  let streams = {};
+  this.stats = {};
+  this.write = function( row ){
+    let keys = Object.keys(row);
+
+    // first time writing to this meta file
+    if( !streams.hasOwnProperty( row.placetype ) ){
+
+      // create write stream
+      streams[row.placetype] = fs.createWriteStream(
+        path.join( metaDir, `wof-${row.placetype}-latest.csv` )
+      );
+
+      // init stats
+      this.stats[row.placetype] = 0;
+
+      // write csv header
+      streams[row.placetype].write( keys.join(',') + '\n' );
+    }
+
+    // write csv row
+    streams[row.placetype].write( keys.map(key => {
+      // quote fields containing comma or newline, escape internal quotes
+      // https://gist.github.com/getify/3667624
+      if( /[,\n]/.test( row[key] ) ) {
+        return '"' + row[key].replace(/\\([\s\S])|(")/g,'\\$1$2') + '"';
+      }
+      return row[key];
+    }).join(',') + '\n' );
+
+    // increment stats
+    this.stats[row.placetype]++;
+  };
+};

--- a/utils/sqlite_download.js
+++ b/utils/sqlite_download.js
@@ -16,15 +16,15 @@ const downloadFunctions = config.sqliteDatabases.map(entry => {
   return (done) => {
 
     // build shell command
+    const options = { cwd: path.basename(__dirname) };
     const cmd = util.format(
-      'curl https://dist.whosonfirst.org/sqlite/%s.bz2 | bunzip2 > %s',
+      './sqlite_download.sh %s %s',
       entry.filename,
       path.join( entry.path, entry.filename )
     );
 
-    console.log('downloading: ' + entry.filename);
-    child_process.exec(cmd, (error, stdout, stderr) => {
-      console.log('done downloading: ' + entry.filename);
+    child_process.exec(cmd, options, (error, stdout, stderr) => {
+      if( stderr.trim().length ){ console.log( stderr.trim() ); }
       if( error ){
         console.error('error downloading: ' + entry.filename + ': ' + error);
         console.error( stderr );
@@ -41,6 +41,10 @@ const downloadFunctions = config.sqliteDatabases.map(entry => {
 const simultaneousDownloads = Math.max(4, Math.min(1, os.cpus().length / 2));
 
 // download all files
-async.parallelLimit(downloadFunctions, simultaneousDownloads, () => {
-  console.error( 'done!' );
-});
+async.parallelLimit(downloadFunctions, simultaneousDownloads, () => {});
+
+// no databases specified
+if( !downloadFunctions.length ){
+  console.error('no sqlite databases specified!');
+  process.exit(1);
+}

--- a/utils/sqlite_download.js
+++ b/utils/sqlite_download.js
@@ -53,12 +53,6 @@ function download(options, callback){
 
   // download all files
   async.parallelLimit(downloadFunctions, simultaneousDownloads, callback);
-
-  // no databases specified
-  if( !downloadFunctions.length ){
-    console.error('no sqlite databases specified!');
-    process.exit(1);
-  }
 }
 
 module.exports.download = download;

--- a/utils/sqlite_download.js
+++ b/utils/sqlite_download.js
@@ -1,0 +1,46 @@
+
+const os = require('os');
+const util = require('util');
+const path = require('path');
+const fs = require('fs-extra');
+const child_process = require('child_process');
+const async = require('async');
+const common = require('./sqlite_common');
+
+// load configuration variables
+const config = require('pelias-config').generate(require('../schema')).imports.whosonfirst;
+common.validateConfig(config, false);
+
+// generate a download function per database listed in config
+const downloadFunctions = config.sqliteDatabases.map(entry => {
+  return (done) => {
+
+    // build shell command
+    const cmd = util.format(
+      'curl https://dist.whosonfirst.org/sqlite/%s.bz2 | bunzip2 > %s',
+      entry.filename,
+      path.join( entry.path, entry.filename )
+    );
+
+    console.log('downloading: ' + entry.filename);
+    child_process.exec(cmd, (error, stdout, stderr) => {
+      console.log('done downloading: ' + entry.filename);
+      if( error ){
+        console.error('error downloading: ' + entry.filename + ': ' + error);
+        console.error( stderr );
+      }
+      done();
+    });
+  };
+});
+
+// download one database for every other CPU (tar and bzip2 can both max out one core)
+// (but not more than 4, to keep things from getting too intense)
+// lower this number to make the downloader more CPU friendly
+// raise this number to (possibly) make it faster
+const simultaneousDownloads = Math.max(4, Math.min(1, os.cpus().length / 2));
+
+// download all files
+async.parallelLimit(downloadFunctions, simultaneousDownloads, () => {
+  console.error( 'done!' );
+});

--- a/utils/sqlite_download.js
+++ b/utils/sqlite_download.js
@@ -55,7 +55,7 @@ function download(callback){
   const simultaneousDownloads = Math.max(4, Math.min(1, os.cpus().length / 2));
 
   // download all files
-  async.parallelLimit(downloadFunctions, simultaneousDownloads, () => {});
+  async.parallelLimit(downloadFunctions, simultaneousDownloads, callback);
 
   // no databases specified
   if( !downloadFunctions.length ){

--- a/utils/sqlite_download.js
+++ b/utils/sqlite_download.js
@@ -11,6 +11,8 @@ function download(options, callback){
 
   // load configuration variables
   const config = require('pelias-config').generate(require('../schema')).imports.whosonfirst;
+  const sqliteDir = path.join(config.datapath, 'sqlite');
+  fs.ensureDirSync(sqliteDir);
 
   // generate a download function per database listed in config
   const downloadFunctions = options.databases.map(filename => {
@@ -19,7 +21,7 @@ function download(options, callback){
       // build shell command
       const options = { cwd: path.basename(__dirname) };
       const cmd = './sqlite_download.sh';
-      const args = [ filename, path.join( config.datapath, filename ) ];
+      const args = [ filename, path.join( sqliteDir, filename ) ];
       const child = child_process.spawn(cmd, args, options);
 
       // handle stdio

--- a/utils/sqlite_download.js
+++ b/utils/sqlite_download.js
@@ -7,44 +7,61 @@ const child_process = require('child_process');
 const async = require('async');
 const common = require('./sqlite_common');
 
-// load configuration variables
-const config = require('pelias-config').generate(require('../schema')).imports.whosonfirst;
-common.validateConfig(config, false);
+function download(callback){
 
-// generate a download function per database listed in config
-const downloadFunctions = config.sqliteDatabases.map(entry => {
-  return (done) => {
+  // load configuration variables
+  const config = require('pelias-config').generate(require('../schema')).imports.whosonfirst;
+  common.validateConfig(config, false);
 
-    // build shell command
-    const options = { cwd: path.basename(__dirname) };
-    const cmd = util.format(
-      './sqlite_download.sh %s %s',
-      entry.filename,
-      path.join( entry.path, entry.filename )
-    );
+  // generate a download function per database listed in config
+  const downloadFunctions = config.sqliteDatabases.map(entry => {
+    return (done) => {
 
-    child_process.exec(cmd, options, (error, stdout, stderr) => {
-      if( stderr.trim().length ){ console.log( stderr.trim() ); }
-      if( error ){
-        console.error('error downloading: ' + entry.filename + ': ' + error);
-        console.error( stderr );
+      // build shell command
+      const options = { cwd: path.basename(__dirname) };
+      const cmd = './sqlite_download.sh';
+      const args = [ entry.filename, path.join( entry.path, entry.filename ) ];
+      const child = child_process.spawn(cmd, args, options);
+
+      // handle stdio
+      function stdio( ioname, buffer ){
+        child[ioname].on('data', data => {
+          buffer += data;
+          let line = data.toString().trim();
+          if( line.length ){ console.log( line ); }
+        });
       }
-      done();
-    });
-  };
-});
 
-// download one database for every other CPU (tar and bzip2 can both max out one core)
-// (but not more than 4, to keep things from getting too intense)
-// lower this number to make the downloader more CPU friendly
-// raise this number to (possibly) make it faster
-const simultaneousDownloads = Math.max(4, Math.min(1, os.cpus().length / 2));
+      var stdout, stderr;
+      stdio( 'stdout', stdout );
+      stdio( 'stderr', stderr );
 
-// download all files
-async.parallelLimit(downloadFunctions, simultaneousDownloads, () => {});
+      // handle exit code
+      child.on('exit', code => {
+        if( '0' !== code.toString() ){
+          console.error('error downloading: ' + entry.filename);
+          console.error(stdout);
+          console.error(stderr);
+        }
+        done();
+      });
+    };
+  });
 
-// no databases specified
-if( !downloadFunctions.length ){
-  console.error('no sqlite databases specified!');
-  process.exit(1);
+  // download one database for every other CPU (tar and bzip2 can both max out one core)
+  // (but not more than 4, to keep things from getting too intense)
+  // lower this number to make the downloader more CPU friendly
+  // raise this number to (possibly) make it faster
+  const simultaneousDownloads = Math.max(4, Math.min(1, os.cpus().length / 2));
+
+  // download all files
+  async.parallelLimit(downloadFunctions, simultaneousDownloads, () => {});
+
+  // no databases specified
+  if( !downloadFunctions.length ){
+    console.error('no sqlite databases specified!');
+    process.exit(1);
+  }
 }
+
+module.exports.download = download;

--- a/utils/sqlite_download.js
+++ b/utils/sqlite_download.js
@@ -7,20 +7,19 @@ const child_process = require('child_process');
 const async = require('async');
 const common = require('./sqlite_common');
 
-function download(callback){
+function download(options, callback){
 
   // load configuration variables
   const config = require('pelias-config').generate(require('../schema')).imports.whosonfirst;
-  common.validateConfig(config, false);
 
   // generate a download function per database listed in config
-  const downloadFunctions = config.sqliteDatabases.map(entry => {
+  const downloadFunctions = options.databases.map(filename => {
     return (done) => {
 
       // build shell command
       const options = { cwd: path.basename(__dirname) };
       const cmd = './sqlite_download.sh';
-      const args = [ entry.filename, path.join( entry.path, entry.filename ) ];
+      const args = [ filename, path.join( config.datapath, filename ) ];
       const child = child_process.spawn(cmd, args, options);
 
       // handle stdio
@@ -39,9 +38,7 @@ function download(callback){
       // handle exit code
       child.on('exit', code => {
         if( '0' !== code.toString() ){
-          console.error('error downloading: ' + entry.filename);
-          console.error(stdout);
-          console.error(stderr);
+          console.error('error downloading: ' + filename);
         }
         done();
       });

--- a/utils/sqlite_download.sh
+++ b/utils/sqlite_download.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# whosonfirst sqlite database downloader
+# this script handles the download & extract of whosonfirst bundles.
+# an additonal '.timestamp' file is saved next to the extracted database
+# in order to avoid re-downloading the same file on subsequent executions.
+
+# input params:
+# $1) name of database without path or bz2 suffix
+#  eg. 'whosonfirst-data-postalcode-ad-latest.db'
+# $2) absolute path of database without bz2 suffix
+#  eg. '/tmp/whosonfirst-data-postalcode-ad-latest.db'
+
+# you can find a list of available bundles at:
+# https://dist.whosonfirst.org/sqlite/
+
+DB_FILENAME="$1"
+LOCAL_DB_PATH="$2"
+LOCAL_BZ2_PATH="$2.bz2"
+LOCAL_TS_PATH="${LOCAL_DB_PATH}.timestamp"
+REMOTE='https://dist.whosonfirst.org/sqlite'
+REMOTE_PATH="${REMOTE}/${DB_FILENAME}.bz2"
+
+info() { echo -e "\e[33m[$1]\t\e[0m $2" >&2; }
+err() { echo -e "\e[31m[$1]\t\e[0m \e[91m$2\e[0m" >&2; }
+extract_file() {
+  info 'extract' "${LOCAL_BZ2_PATH}"
+  bunzip2 -f "${LOCAL_BZ2_PATH}" > "${LOCAL_DB_PATH}"
+}
+generate_timestamp() {
+  printf "@" > "${LOCAL_TS_PATH}" # date command requires @ prefix
+  stat -c %Y "${LOCAL_DB_PATH}" >> "${LOCAL_TS_PATH}"
+}
+download_handler() {
+  HTTP_STATUS="${1}"
+  if [[ "${HTTP_STATUS}" == "200" ]]; then
+    extract_file; generate_timestamp
+  elif [[ "${HTTP_STATUS}" == "304" ]]; then
+    info 'not modified' "${DB_FILENAME}"
+  else
+    rm -f "${LOCAL_BZ2_PATH}"
+    err "status ${HTTP_STATUS}" "${REMOTE_PATH}"
+  fi
+}
+download_sqlite_db() {
+  info 'download' "${REMOTE_PATH}"
+  if [[ ! -f "${LOCAL_TS_PATH}" ]]; then
+    # first download
+    download_handler $(curl "${REMOTE_PATH}" \
+      -o "${LOCAL_BZ2_PATH}" -s -L -w %{http_code})
+  else
+    # subsequent download
+    LAST_MODIFIED=$(date --rfc-2822 -f "${LOCAL_TS_PATH}")
+    download_handler $(curl -s "${REMOTE_PATH}" \
+      -z "${LAST_MODIFIED}" \
+      -o "${LOCAL_BZ2_PATH}" -s -L -w %{http_code})
+  fi
+}
+
+download_sqlite_db;

--- a/utils/sqlite_download.sh
+++ b/utils/sqlite_download.sh
@@ -24,7 +24,7 @@ REMOTE_PATH="${REMOTE}/${DB_FILENAME}.bz2"
 info() { echo -e "\e[33m[$1]\t\e[0m $2" >&2; }
 err() { echo -e "\e[31m[$1]\t\e[0m \e[91m$2\e[0m" >&2; }
 extract_file() {
-  info 'extract' "${LOCAL_BZ2_PATH}"
+  info 'decompress' "${LOCAL_BZ2_PATH}"
   bunzip2 -f "${LOCAL_BZ2_PATH}" > "${LOCAL_DB_PATH}"
 }
 generate_timestamp() {
@@ -34,7 +34,7 @@ generate_timestamp() {
 download_handler() {
   HTTP_STATUS="${1}"
   if [[ "${HTTP_STATUS}" == "200" ]]; then
-    extract_file; generate_timestamp
+    extract_file && generate_timestamp
   elif [[ "${HTTP_STATUS}" == "304" ]]; then
     info 'not modified' "${DB_FILENAME}"
   else

--- a/utils/sqlite_extract_data.js
+++ b/utils/sqlite_extract_data.js
@@ -125,6 +125,8 @@ function extract(options, callback){
     for( let row of db.prepare(sql.data).iterate({ wofid: targetWofId }) ){
       if( 'postalcode' === row.placetype && true !== config.importPostalcodes ){ return; }
       if( 'venue' === row.placetype && true !== config.importVenues ){ return; }
+      if( 'constituency' === row.placetype && true !== config.importConstituencies ){ return; }
+      if( 'intersection' === row.placetype && true !== config.importIntersections ){ return; }
       writeJson( row );
     }
 
@@ -132,6 +134,8 @@ function extract(options, callback){
     for( let row of db.prepare(sql.meta).iterate({ wofid: targetWofId }) ){
       if( 'postalcode' === row.placetype && true !== config.importPostalcodes ){ return; }
       if( 'venue' === row.placetype && true !== config.importVenues ){ return; }
+      if( 'constituency' === row.placetype && true !== config.importConstituencies ){ return; }
+      if( 'intersection' === row.placetype && true !== config.importIntersections ){ return; }
       if( !row.hasOwnProperty('path') ){
         // ensure path property is present (required by some importers)
         row.path = wofIdToPath(row.id).concat(row.id+'.geojson').join(path.sep);

--- a/utils/sqlite_extract_data.js
+++ b/utils/sqlite_extract_data.js
@@ -109,7 +109,7 @@ function MetaDataFiles(){
 
       // create write stream
       streams[row.placetype] = fs.createWriteStream(
-        path.join( metaDir, `${row.placetype}.csv` )
+        path.join( metaDir, `wof-${row.placetype}-latest.csv` )
       );
 
       // write csv header

--- a/utils/sqlite_extract_data.js
+++ b/utils/sqlite_extract_data.js
@@ -1,141 +1,160 @@
 
 const fs = require('fs-extra');
 const path = require('path');
+const util = require('util');
 const Sqlite3 = require('better-sqlite3');
 const common = require('./sqlite_common');
 const wofIdToPath = require('../src/wofIdToPath');
 
-// load configuration variables
-const config = require('pelias-config').generate(require('../schema')).imports.whosonfirst;
-common.validateConfig(config, true);
+function extract(options, callback){
 
-// ensure required directory structure exists
-const metaDir = path.join(config.datapath, 'meta');
-const dataDir = path.join(config.datapath, 'data');
-fs.ensureDirSync(metaDir);
-fs.ensureDirSync(dataDir);
+  // load configuration variables
+  const config = require('pelias-config').generate(require('../schema')).imports.whosonfirst;
+  common.validateConfig(config, true);
 
-// sql statements
-const sql = {
-  data: `SELECT spr.id, spr.placetype, geojson.body FROM geojson
-  JOIN spr ON geojson.id = spr.id
-  WHERE spr.id IN (
-    SELECT @wofid
-    UNION
-    SELECT DISTINCT id
-    FROM ancestors
-    WHERE ancestor_id = @wofid
-    UNION
-    SELECT DISTINCT ancestor_id
-    FROM ancestors
-    WHERE id = @wofid
-  );`,
-  meta: `SELECT
-    json_extract(body, '$.bbox[0]') || ',' ||
-    json_extract(body, '$.bbox[1]') || ',' ||
-    json_extract(body, '$.bbox[2]') || ',' ||
-    json_extract(body, '$.bbox[3]') AS bbox,
-    json_extract(body, '$.properties.edtf:cessation') AS cessation,
-    json_extract(body, '$.properties.wof:hierarchy[0].country_id') AS country_id,
-    json_extract(body, '$.properties.edtf:deprecated') AS deprecated,
-    "" AS file_hash,
-    "" AS fullname,
-    json_extract(body, '$.properties.geom:hash') AS geom_hash,
-    json_extract(body, '$.properties.geom:latitude') AS geom_latitude,
-    json_extract(body, '$.properties.geom:longitude') AS geom_longitude,
-    json_extract(body, '$.properties.wof:id') AS id,
-    json_extract(body, '$.properties.edtf:inception') AS inception,
-    json_extract(body, '$.properties.iso:country') AS iso,
-    json_extract(body, '$.properties.iso:country') AS iso_country,
-    json_extract(body, '$.properties.wof:lastmodified') AS lastmodified,
-    json_extract(body, '$.properties.lbl:latitude') AS lbl_latitude,
-    json_extract(body, '$.properties.lbl:longitude') AS lbl_longitude,
-    json_extract(body, '$.properties.wof:hierarchy[0].locality_id') AS locality_id,
-    json_extract(body, '$.properties.wof:name') AS name,
-    json_extract(body, '$.properties.wof:parent_id') AS parent_id,
-    REPLACE(
+  // location of data and meta dirs
+  const metaDir = path.join(config.datapath, 'meta');
+  const dataDir = path.join(config.datapath, 'data');
+
+  // unlink (truncate meta and data dirs)
+  if( options && true === options.unlink ){
+    fs.removeSync(metaDir);
+    fs.removeSync(dataDir);
+  }
+
+  // ensure required directory structure exists
+  fs.ensureDirSync(metaDir);
+  fs.ensureDirSync(dataDir);
+
+  // sql statements
+  const sql = {
+    data: `SELECT spr.id, spr.placetype, geojson.body FROM geojson
+    JOIN spr ON geojson.id = spr.id
+    WHERE spr.id IN (
+      SELECT @wofid
+      UNION
+      SELECT DISTINCT id
+      FROM ancestors
+      WHERE ancestor_id = @wofid
+      UNION
+      SELECT DISTINCT ancestor_id
+      FROM ancestors
+      WHERE id = @wofid
+    );`,
+    meta: `SELECT
+      json_extract(body, '$.bbox[0]') || ',' ||
+      json_extract(body, '$.bbox[1]') || ',' ||
+      json_extract(body, '$.bbox[2]') || ',' ||
+      json_extract(body, '$.bbox[3]') AS bbox,
+      json_extract(body, '$.properties.edtf:cessation') AS cessation,
+      json_extract(body, '$.properties.wof:hierarchy[0].country_id') AS country_id,
+      json_extract(body, '$.properties.edtf:deprecated') AS deprecated,
+      "" AS file_hash,
+      "" AS fullname,
+      json_extract(body, '$.properties.geom:hash') AS geom_hash,
+      json_extract(body, '$.properties.geom:latitude') AS geom_latitude,
+      json_extract(body, '$.properties.geom:longitude') AS geom_longitude,
+      json_extract(body, '$.properties.wof:id') AS id,
+      json_extract(body, '$.properties.edtf:inception') AS inception,
+      json_extract(body, '$.properties.iso:country') AS iso,
+      json_extract(body, '$.properties.iso:country') AS iso_country,
+      json_extract(body, '$.properties.wof:lastmodified') AS lastmodified,
+      json_extract(body, '$.properties.lbl:latitude') AS lbl_latitude,
+      json_extract(body, '$.properties.lbl:longitude') AS lbl_longitude,
+      json_extract(body, '$.properties.wof:hierarchy[0].locality_id') AS locality_id,
+      json_extract(body, '$.properties.wof:name') AS name,
+      json_extract(body, '$.properties.wof:parent_id') AS parent_id,
       REPLACE(
-        SUBSTR(json_extract(body, '$.properties.wof:id'),1,3) ||'/'||
-        SUBSTR(json_extract(body, '$.properties.wof:id'),4,3) ||'/'||
-        SUBSTR(json_extract(body, '$.properties.wof:id'),7,3) ||'/'||
-        SUBSTR(json_extract(body, '$.properties.wof:id'),10)  ||'/'||
-        json_extract(body, '$.properties.wof:id') || '.geojson',
-      '//', '/'),
-    '//','/') AS path,
-    json_extract(body, '$.properties.wof:placetype') AS placetype,
-    json_extract(body, '$.properties.wof:hierarchy[0].region_id') AS region_id,
-    json_extract(body, '$.properties.src:geom') AS source,
-    json_extract(body, '$.properties.wof:superseded_by[0]') AS superseded_by,
-    json_extract(body, '$.properties.wof:supersedes[0]') AS supersedes,
-    json_extract(body, '$.properties.wof:country') AS wof_country
-  FROM geojson
-  WHERE id IN (
-    SELECT @wofid
-    UNION
-    SELECT DISTINCT id
-    FROM ancestors
-    WHERE ancestor_id = @wofid
-    UNION
-    SELECT DISTINCT ancestor_id
-    FROM ancestors
-    WHERE id = @wofid
-  );`
-};
+        REPLACE(
+          SUBSTR(json_extract(body, '$.properties.wof:id'),1,3) ||'/'||
+          SUBSTR(json_extract(body, '$.properties.wof:id'),4,3) ||'/'||
+          SUBSTR(json_extract(body, '$.properties.wof:id'),7,3) ||'/'||
+          SUBSTR(json_extract(body, '$.properties.wof:id'),10)  ||'/'||
+          json_extract(body, '$.properties.wof:id') || '.geojson',
+        '//', '/'),
+      '//','/') AS path,
+      json_extract(body, '$.properties.wof:placetype') AS placetype,
+      json_extract(body, '$.properties.wof:hierarchy[0].region_id') AS region_id,
+      json_extract(body, '$.properties.src:geom') AS source,
+      json_extract(body, '$.properties.wof:superseded_by[0]') AS superseded_by,
+      json_extract(body, '$.properties.wof:supersedes[0]') AS supersedes,
+      json_extract(body, '$.properties.wof:country') AS wof_country
+    FROM geojson
+    WHERE id IN (
+      SELECT @wofid
+      UNION
+      SELECT DISTINCT id
+      FROM ancestors
+      WHERE ancestor_id = @wofid
+      UNION
+      SELECT DISTINCT ancestor_id
+      FROM ancestors
+      WHERE id = @wofid
+    );`
+  };
 
-// open one write stream per metadata file
-// note: important for to ensure meta files are written correctly
-// with only one header per import run
-const metafiles = new common.MetaDataFiles( metaDir );
+  // open one write stream per metadata file
+  // note: important for to ensure meta files are written correctly
+  // with only one header per import run
+  const metafiles = new common.MetaDataFiles( metaDir );
 
-// extract from a single db file
-function extract( dbpath ){
-  let targetWofId = config.importPlace;
+  // extract from a single db file
+  function extract( dbpath ){
+    let targetWofId = config.importPlace;
 
-  // connect to sql db
-  let db = new Sqlite3( dbpath, { readonly: true } );
+    // connect to sql db
+    let db = new Sqlite3( dbpath, { readonly: true } );
 
-  // extract all data to disk
-  for( let row of db.prepare(sql.data).iterate({ wofid: targetWofId }) ){
-    if( 'postalcode' === row.placetype && true !== config.importPostalcodes ){ return; }
-    if( 'venue' === row.placetype && true !== config.importVenues ){ return; }
-    writeJson( row );
-  }
-
-  // write meta data to disk
-  for( let row of db.prepare(sql.meta).iterate({ wofid: targetWofId }) ){
-    if( 'postalcode' === row.placetype && true !== config.importPostalcodes ){ return; }
-    if( 'venue' === row.placetype && true !== config.importVenues ){ return; }
-    if( !row.hasOwnProperty('path') ){
-      // ensure path property is present (required by some importers)
-      row.path = wofIdToPath(row.id).concat(row.id+'.geojson').join(path.sep);
+    // extract all data to disk
+    for( let row of db.prepare(sql.data).iterate({ wofid: targetWofId }) ){
+      if( 'postalcode' === row.placetype && true !== config.importPostalcodes ){ return; }
+      if( 'venue' === row.placetype && true !== config.importVenues ){ return; }
+      writeJson( row );
     }
-    metafiles.write( row );
+
+    // write meta data to disk
+    for( let row of db.prepare(sql.meta).iterate({ wofid: targetWofId }) ){
+      if( 'postalcode' === row.placetype && true !== config.importPostalcodes ){ return; }
+      if( 'venue' === row.placetype && true !== config.importVenues ){ return; }
+      if( !row.hasOwnProperty('path') ){
+        // ensure path property is present (required by some importers)
+        row.path = wofIdToPath(row.id).concat(row.id+'.geojson').join(path.sep);
+      }
+      metafiles.write( row );
+    }
+
+    // close connection
+    db.close();
   }
 
-  // close connection
-  db.close();
-}
-
-// extract from all database files
-config.sqliteDatabases.forEach( entry => {
-  extract( path.join( entry.path, entry.filename ) );
-});
-
-// print stats
-console.error( '--- sqlite extract complete ---' );
-if( Object.keys( metafiles.stats ).length ){
-  Object.keys( metafiles.stats ).forEach( key => console.error( key, metafiles.stats[key]) );
-} else {
-  console.error( 'failed to extract any records!' );
-}
-
-// ----------------------------------------------------------------------------
-
-// write json to disk
-function writeJson( row ){
-  let targetDir = path.join(dataDir, wofIdToPath(row.id).join(path.sep));
-  fs.ensureDir(targetDir, (error) => {
-    if( error ){ console.error(`error making directory ${targetDir}`); }
-    fs.writeFileSync( path.join(targetDir, `${row.id}.geojson`), row.body, 'utf8' );
+  // extract from all database files
+  config.sqliteDatabases.forEach( entry => {
+    extract( path.join( entry.path, entry.filename ) );
   });
+
+  // print stats
+  if( Object.keys( metafiles.stats ).length ){
+    Object.keys( metafiles.stats ).forEach( key => {
+      console.error( util.format('extracted %d %s(s)',
+        metafiles.stats[key], key
+      ));
+    });
+  } else {
+    console.error( 'failed to extract any records!' );
+  }
+
+  callback();
+
+  // ----------------------------------------------------------------------------
+
+  // write json to disk
+  function writeJson( row ){
+    let targetDir = path.join(dataDir, wofIdToPath(row.id).join(path.sep));
+    fs.ensureDir(targetDir, (error) => {
+      if( error ){ console.error(`error making directory ${targetDir}`); }
+      fs.writeFileSync( path.join(targetDir, `${row.id}.geojson`), row.body, 'utf8' );
+    });
+  }
 }
+
+module.exports.extract = extract;

--- a/utils/sqlite_extract_data.js
+++ b/utils/sqlite_extract_data.js
@@ -21,8 +21,9 @@ fs.ensureDirSync(dataDir);
 
 // sql statements
 const sql = {
-  data: `SELECT id, body FROM geojson
-  WHERE id IN (
+  data: `SELECT spr.id, spr.placetype, geojson.body FROM geojson
+  JOIN spr ON geojson.id = spr.id
+  WHERE spr.id IN (
     SELECT id
     FROM ancestors
     WHERE id = @wofid
@@ -55,11 +56,15 @@ function extract( dbpath ){
 
   // extract all data to disk
   for( let row of db.prepare(sql.data).iterate({ wofid: targetWofId }) ){
+    if( 'postalcode' === row.placetype && true !== config.importPostalcodes ){ return; }
+    if( 'venue' === row.placetype && true !== config.importVenues ){ return; }
     writeJson( row );
   }
 
   // write meta data to disk
   for( let row of db.prepare(sql.meta).iterate({ wofid: targetWofId }) ){
+    if( 'postalcode' === row.placetype && true !== config.importPostalcodes ){ return; }
+    if( 'venue' === row.placetype && true !== config.importVenues ){ return; }
     metafiles.write( row );
   }
 

--- a/utils/sqlite_extract_data.js
+++ b/utils/sqlite_extract_data.js
@@ -2,6 +2,7 @@
 const fs = require('fs-extra');
 const path = require('path');
 const Sqlite3 = require('better-sqlite3');
+const wofIdToPath = require('../src/wofIdToPath');
 
 // load configuration variables
 const config = require( 'pelias-config' ).generate(require('../schema')).imports.whosonfirst;
@@ -84,18 +85,6 @@ function writeJson( row ){
     if( error ){ console.error(`error making directory ${targetDir}`); }
     fs.writeFileSync( path.join(targetDir, `${row.id}.geojson`), row.body, 'utf8' );
   });
-}
-
-// convert wofid integer to array of path components
-function wofIdToPath( id ){
-  let strId = id.toString();
-  let parts = [];
-  while( strId.length ){
-    let part = strId.substr(0, 3);
-    parts.push(part);
-    strId = strId.substr(3);
-  }
-  return parts;
 }
 
 // handler for all metatdata streams

--- a/utils/sqlite_extract_data.js
+++ b/utils/sqlite_extract_data.js
@@ -66,6 +66,10 @@ function extract( dbpath ){
   for( let row of db.prepare(sql.meta).iterate({ wofid: targetWofId }) ){
     if( 'postalcode' === row.placetype && true !== config.importPostalcodes ){ return; }
     if( 'venue' === row.placetype && true !== config.importVenues ){ return; }
+    if( !row.hasOwnProperty('path') ){
+      // ensure path property is present (required by some importers)
+      row.path = wofIdToPath(row.id).join(path.sep);
+    }
     metafiles.write( row );
   }
 

--- a/utils/sqlite_extract_data.js
+++ b/utils/sqlite_extract_data.js
@@ -6,11 +6,94 @@ const Sqlite3 = require('better-sqlite3');
 const common = require('./sqlite_common');
 const wofIdToPath = require('../src/wofIdToPath');
 
+// sql statements
+const sql = {
+  data: `SELECT spr.id, spr.placetype, geojson.body FROM geojson
+  JOIN spr ON geojson.id = spr.id
+  WHERE spr.id IN (
+    SELECT @wofid
+    UNION
+    SELECT DISTINCT id
+    FROM ancestors
+    WHERE ancestor_id = @wofid
+    UNION
+    SELECT DISTINCT ancestor_id
+    FROM ancestors
+    WHERE id = @wofid
+  );`,
+  meta: `SELECT
+    json_extract(body, '$.bbox[0]') || ',' ||
+    json_extract(body, '$.bbox[1]') || ',' ||
+    json_extract(body, '$.bbox[2]') || ',' ||
+    json_extract(body, '$.bbox[3]') AS bbox,
+    json_extract(body, '$.properties.edtf:cessation') AS cessation,
+    json_extract(body, '$.properties.wof:hierarchy[0].country_id') AS country_id,
+    json_extract(body, '$.properties.edtf:deprecated') AS deprecated,
+    "" AS file_hash,
+    "" AS fullname,
+    json_extract(body, '$.properties.geom:hash') AS geom_hash,
+    json_extract(body, '$.properties.geom:latitude') AS geom_latitude,
+    json_extract(body, '$.properties.geom:longitude') AS geom_longitude,
+    json_extract(body, '$.properties.wof:id') AS id,
+    json_extract(body, '$.properties.edtf:inception') AS inception,
+    json_extract(body, '$.properties.iso:country') AS iso,
+    json_extract(body, '$.properties.iso:country') AS iso_country,
+    json_extract(body, '$.properties.wof:lastmodified') AS lastmodified,
+    json_extract(body, '$.properties.lbl:latitude') AS lbl_latitude,
+    json_extract(body, '$.properties.lbl:longitude') AS lbl_longitude,
+    json_extract(body, '$.properties.wof:hierarchy[0].locality_id') AS locality_id,
+    json_extract(body, '$.properties.wof:name') AS name,
+    json_extract(body, '$.properties.wof:parent_id') AS parent_id,
+    REPLACE(
+      REPLACE(
+        SUBSTR(json_extract(body, '$.properties.wof:id'),1,3) ||'/'||
+        SUBSTR(json_extract(body, '$.properties.wof:id'),4,3) ||'/'||
+        SUBSTR(json_extract(body, '$.properties.wof:id'),7,3) ||'/'||
+        SUBSTR(json_extract(body, '$.properties.wof:id'),10)  ||'/'||
+        json_extract(body, '$.properties.wof:id') || '.geojson',
+      '//', '/'),
+    '//','/') AS path,
+    json_extract(body, '$.properties.wof:placetype') AS placetype,
+    json_extract(body, '$.properties.wof:hierarchy[0].region_id') AS region_id,
+    json_extract(body, '$.properties.src:geom') AS source,
+    json_extract(body, '$.properties.wof:superseded_by[0]') AS superseded_by,
+    json_extract(body, '$.properties.wof:supersedes[0]') AS supersedes,
+    json_extract(body, '$.properties.wof:country') AS wof_country
+  FROM geojson
+  WHERE id IN (
+    SELECT @wofid
+    UNION
+    SELECT DISTINCT id
+    FROM ancestors
+    WHERE ancestor_id = @wofid
+    UNION
+    SELECT DISTINCT ancestor_id
+    FROM ancestors
+    WHERE id = @wofid
+  );`,
+  subdiv: `SELECT DISTINCT LOWER( IFNULL(
+    json_extract(body, '$.properties."wof:subdivision"'),
+    json_extract(body, '$.properties."iso:country"')
+  )) AS subdivision
+  FROM geojson
+  WHERE id IN (
+    SELECT @wofid
+    UNION
+    SELECT DISTINCT id
+    FROM ancestors
+    WHERE ancestor_id = @wofid
+    UNION
+    SELECT DISTINCT ancestor_id
+    FROM ancestors
+    WHERE id = @wofid
+  )
+  AND subdivision != '';`,
+};
+
 function extract(options, callback){
 
   // load configuration variables
   const config = require('pelias-config').generate(require('../schema')).imports.whosonfirst;
-  common.validateConfig(config, true);
 
   // location of data and meta dirs
   const metaDir = path.join(config.datapath, 'meta');
@@ -26,80 +109,13 @@ function extract(options, callback){
   fs.ensureDirSync(metaDir);
   fs.ensureDirSync(dataDir);
 
-  // sql statements
-  const sql = {
-    data: `SELECT spr.id, spr.placetype, geojson.body FROM geojson
-    JOIN spr ON geojson.id = spr.id
-    WHERE spr.id IN (
-      SELECT @wofid
-      UNION
-      SELECT DISTINCT id
-      FROM ancestors
-      WHERE ancestor_id = @wofid
-      UNION
-      SELECT DISTINCT ancestor_id
-      FROM ancestors
-      WHERE id = @wofid
-    );`,
-    meta: `SELECT
-      json_extract(body, '$.bbox[0]') || ',' ||
-      json_extract(body, '$.bbox[1]') || ',' ||
-      json_extract(body, '$.bbox[2]') || ',' ||
-      json_extract(body, '$.bbox[3]') AS bbox,
-      json_extract(body, '$.properties.edtf:cessation') AS cessation,
-      json_extract(body, '$.properties.wof:hierarchy[0].country_id') AS country_id,
-      json_extract(body, '$.properties.edtf:deprecated') AS deprecated,
-      "" AS file_hash,
-      "" AS fullname,
-      json_extract(body, '$.properties.geom:hash') AS geom_hash,
-      json_extract(body, '$.properties.geom:latitude') AS geom_latitude,
-      json_extract(body, '$.properties.geom:longitude') AS geom_longitude,
-      json_extract(body, '$.properties.wof:id') AS id,
-      json_extract(body, '$.properties.edtf:inception') AS inception,
-      json_extract(body, '$.properties.iso:country') AS iso,
-      json_extract(body, '$.properties.iso:country') AS iso_country,
-      json_extract(body, '$.properties.wof:lastmodified') AS lastmodified,
-      json_extract(body, '$.properties.lbl:latitude') AS lbl_latitude,
-      json_extract(body, '$.properties.lbl:longitude') AS lbl_longitude,
-      json_extract(body, '$.properties.wof:hierarchy[0].locality_id') AS locality_id,
-      json_extract(body, '$.properties.wof:name') AS name,
-      json_extract(body, '$.properties.wof:parent_id') AS parent_id,
-      REPLACE(
-        REPLACE(
-          SUBSTR(json_extract(body, '$.properties.wof:id'),1,3) ||'/'||
-          SUBSTR(json_extract(body, '$.properties.wof:id'),4,3) ||'/'||
-          SUBSTR(json_extract(body, '$.properties.wof:id'),7,3) ||'/'||
-          SUBSTR(json_extract(body, '$.properties.wof:id'),10)  ||'/'||
-          json_extract(body, '$.properties.wof:id') || '.geojson',
-        '//', '/'),
-      '//','/') AS path,
-      json_extract(body, '$.properties.wof:placetype') AS placetype,
-      json_extract(body, '$.properties.wof:hierarchy[0].region_id') AS region_id,
-      json_extract(body, '$.properties.src:geom') AS source,
-      json_extract(body, '$.properties.wof:superseded_by[0]') AS superseded_by,
-      json_extract(body, '$.properties.wof:supersedes[0]') AS supersedes,
-      json_extract(body, '$.properties.wof:country') AS wof_country
-    FROM geojson
-    WHERE id IN (
-      SELECT @wofid
-      UNION
-      SELECT DISTINCT id
-      FROM ancestors
-      WHERE ancestor_id = @wofid
-      UNION
-      SELECT DISTINCT ancestor_id
-      FROM ancestors
-      WHERE id = @wofid
-    );`
-  };
-
   // open one write stream per metadata file
   // note: important for to ensure meta files are written correctly
   // with only one header per import run
   const metafiles = new common.MetaDataFiles( metaDir );
 
   // extract from a single db file
-  function extract( dbpath ){
+  function extractDB( dbpath ){
     let targetWofId = config.importPlace;
 
     // connect to sql db
@@ -128,8 +144,15 @@ function extract(options, callback){
   }
 
   // extract from all database files
-  config.sqliteDatabases.forEach( entry => {
-    extract( path.join( entry.path, entry.filename ) );
+  options.databases.forEach( filename => {
+
+    let dbpath = path.join( config.datapath, filename );
+    if( !fs.existsSync( dbpath ) ){
+      console.error('not found:', dbpath);
+      return;
+    }
+
+    extractDB( dbpath );
   });
 
   // print stats
@@ -140,7 +163,7 @@ function extract(options, callback){
       ));
     });
   } else {
-    console.error( 'failed to extract any records!' );
+    console.error('failed to extract any records!');
   }
 
   callback();
@@ -157,4 +180,20 @@ function extract(options, callback){
   }
 }
 
+// return all distinct subdivisions of the data
+function findSubdivisions( filename ){
+
+  // load configuration variables
+  const config = require('pelias-config').generate(require('../schema')).imports.whosonfirst;
+  let targetWofId = config.importPlace;
+
+  // connect to sql db
+  let db = new Sqlite3( path.join( config.datapath, filename ), { readonly: true } );
+
+  // query db
+  // console.error( sql.subdiv.replace(/@wofid/g, targetWofId) );
+  return db.prepare(sql.subdiv).all({ wofid: targetWofId }).map( row => row.subdivision.toLowerCase());
+}
+
 module.exports.extract = extract;
+module.exports.findSubdivisions = findSubdivisions;

--- a/utils/sqlite_extract_data.js
+++ b/utils/sqlite_extract_data.js
@@ -113,9 +113,10 @@ function MetaDataFiles(){
 
     // write csv row
     streams[row.placetype].write( keys.map(key => {
-      // quote fields containing comma or newline
+      // quote fields containing comma or newline, escape internal quotes
+      // https://gist.github.com/getify/3667624
       if( /[,\n]/.test( row[key] ) ) {
-        return '"' + row[key] + '"';
+        return '"' + row[key].replace(/\\([\s\S])|(")/g,'\\$1$2') + '"';
       }
       return row[key];
     }).join(',') + '\n' );

--- a/utils/sqlite_extract_data.js
+++ b/utils/sqlite_extract_data.js
@@ -35,7 +35,45 @@ const sql = {
     FROM ancestors
     WHERE id = @wofid
   );`,
-  meta: `SELECT * FROM spr
+  meta: `SELECT
+    json_extract(body, '$.bbox[0]') || ',' ||
+    json_extract(body, '$.bbox[1]') || ',' ||
+    json_extract(body, '$.bbox[2]') || ',' ||
+    json_extract(body, '$.bbox[3]') AS bbox,
+    json_extract(body, '$.properties.edtf:cessation') AS cessation,
+    json_extract(body, '$.properties.wof:hierarchy[0].country_id') AS country_id,
+    json_extract(body, '$.properties.edtf:deprecated') AS deprecated,
+    "" AS file_hash,
+    "" AS fullname,
+    json_extract(body, '$.properties.geom:hash') AS geom_hash,
+    json_extract(body, '$.properties.geom:latitude') AS geom_latitude,
+    json_extract(body, '$.properties.geom:longitude') AS geom_longitude,
+    json_extract(body, '$.properties.wof:id') AS id,
+    json_extract(body, '$.properties.edtf:inception') AS inception,
+    json_extract(body, '$.properties.iso:country') AS iso,
+    json_extract(body, '$.properties.iso:country') AS iso_country,
+    json_extract(body, '$.properties.wof:lastmodified') AS lastmodified,
+    json_extract(body, '$.properties.lbl:latitude') AS lbl_latitude,
+    json_extract(body, '$.properties.lbl:longitude') AS lbl_longitude,
+    json_extract(body, '$.properties.wof:hierarchy[0].locality_id') AS locality_id,
+    json_extract(body, '$.properties.wof:name') AS name,
+    json_extract(body, '$.properties.wof:parent_id') AS parent_id,
+    REPLACE(
+      REPLACE(
+        SUBSTR(json_extract(body, '$.properties.wof:id'),1,3) ||'/'||
+        SUBSTR(json_extract(body, '$.properties.wof:id'),4,3) ||'/'||
+        SUBSTR(json_extract(body, '$.properties.wof:id'),7,3) ||'/'||
+        SUBSTR(json_extract(body, '$.properties.wof:id'),10)  ||'/'||
+        json_extract(body, '$.properties.wof:id') || '.geojson',
+      '//', '/'),
+    '//','/') AS path,
+    json_extract(body, '$.properties.wof:placetype') AS placetype,
+    json_extract(body, '$.properties.wof:hierarchy[0].region_id') AS region_id,
+    json_extract(body, '$.properties.src:geom') AS source,
+    json_extract(body, '$.properties.wof:superseded_by[0]') AS superseded_by,
+    json_extract(body, '$.properties.wof:supersedes[0]') AS supersedes,
+    json_extract(body, '$.properties.wof:country') AS wof_country
+  FROM geojson
   WHERE id IN (
     SELECT @wofid
     UNION

--- a/utils/sqlite_extract_data.js
+++ b/utils/sqlite_extract_data.js
@@ -68,7 +68,7 @@ function extract( dbpath ){
     if( 'venue' === row.placetype && true !== config.importVenues ){ return; }
     if( !row.hasOwnProperty('path') ){
       // ensure path property is present (required by some importers)
-      row.path = wofIdToPath(row.id).join(path.sep);
+      row.path = wofIdToPath(row.id).concat(row.id+'.json').join(path.sep);
     }
     metafiles.write( row );
   }

--- a/utils/sqlite_extract_data.js
+++ b/utils/sqlite_extract_data.js
@@ -177,10 +177,12 @@ function extract(options, callback){
   // write json to disk
   function writeJson( row ){
     let targetDir = path.join(dataDir, wofIdToPath(row.id).join(path.sep));
-    fs.ensureDir(targetDir, (error) => {
-      if( error ){ console.error(`error making directory ${targetDir}`); }
+    try {
+      fs.ensureDirSync(targetDir);
       fs.writeFileSync( path.join(targetDir, `${row.id}.geojson`), row.body, 'utf8' );
-    });
+    } catch( error ){
+      if( error ){ console.error(`error making directory ${targetDir}`); }
+    }
   }
 }
 

--- a/utils/sqlite_extract_data.js
+++ b/utils/sqlite_extract_data.js
@@ -68,7 +68,7 @@ function extract( dbpath ){
     if( 'venue' === row.placetype && true !== config.importVenues ){ return; }
     if( !row.hasOwnProperty('path') ){
       // ensure path property is present (required by some importers)
-      row.path = wofIdToPath(row.id).concat(row.id+'.json').join(path.sep);
+      row.path = wofIdToPath(row.id).concat(row.id+'.geojson').join(path.sep);
     }
     metafiles.write( row );
   }

--- a/utils/sqlite_extract_data.js
+++ b/utils/sqlite_extract_data.js
@@ -25,21 +25,27 @@ const sql = {
   data: `SELECT spr.id, spr.placetype, geojson.body FROM geojson
   JOIN spr ON geojson.id = spr.id
   WHERE spr.id IN (
-    SELECT id
+    SELECT @wofid
+    UNION
+    SELECT DISTINCT id
+    FROM ancestors
+    WHERE ancestor_id = @wofid
+    UNION
+    SELECT DISTINCT ancestor_id
     FROM ancestors
     WHERE id = @wofid
-    OR ancestor_id = @wofid
-    GROUP BY id
-    ORDER BY id ASC
   );`,
   meta: `SELECT * FROM spr
   WHERE id IN (
-    SELECT id
+    SELECT @wofid
+    UNION
+    SELECT DISTINCT id
+    FROM ancestors
+    WHERE ancestor_id = @wofid
+    UNION
+    SELECT DISTINCT ancestor_id
     FROM ancestors
     WHERE id = @wofid
-    OR ancestor_id = @wofid
-    GROUP BY id
-    ORDER BY id ASC
   );`
 };
 

--- a/utils/sqlite_extract_data.js
+++ b/utils/sqlite_extract_data.js
@@ -98,6 +98,7 @@ function extract(options, callback){
   // location of data and meta dirs
   const metaDir = path.join(config.datapath, 'meta');
   const dataDir = path.join(config.datapath, 'data');
+  const sqliteDir = path.join(config.datapath, 'sqlite');
 
   // unlink (truncate meta and data dirs)
   if( options && true === options.unlink ){
@@ -108,6 +109,7 @@ function extract(options, callback){
   // ensure required directory structure exists
   fs.ensureDirSync(metaDir);
   fs.ensureDirSync(dataDir);
+  fs.ensureDirSync(sqliteDir);
 
   // open one write stream per metadata file
   // note: important for to ensure meta files are written correctly
@@ -150,7 +152,7 @@ function extract(options, callback){
   // extract from all database files
   options.databases.forEach( filename => {
 
-    let dbpath = path.join( config.datapath, filename );
+    let dbpath = path.join( sqliteDir, filename );
     if( !fs.existsSync( dbpath ) ){
       console.error('not found:', dbpath);
       return;
@@ -191,10 +193,11 @@ function findSubdivisions( filename ){
 
   // load configuration variables
   const config = require('pelias-config').generate(require('../schema')).imports.whosonfirst;
+  const sqliteDir = path.join(config.datapath, 'sqlite');
   let targetWofId = config.importPlace;
 
   // connect to sql db
-  let db = new Sqlite3( path.join( config.datapath, filename ), { readonly: true } );
+  let db = new Sqlite3( path.join( sqliteDir, filename ), { readonly: true } );
 
   // query db
   // console.error( sql.subdiv.replace(/@wofid/g, targetWofId) );

--- a/utils/sqlite_extract_data.js
+++ b/utils/sqlite_extract_data.js
@@ -1,0 +1,107 @@
+
+const fs = require('fs-extra');
+const path = require('path');
+const Sqlite3 = require('better-sqlite3');
+
+// load configuration variables
+const config = require( 'pelias-config' ).generate(require('../schema')).imports.whosonfirst;
+const sqliteFiles = config.sqlite_files;
+
+// ensure sqlite_files array is specified in config
+if( !Array.isArray( config.sqlite_files ) || !config.sqlite_files.length ){
+  console.error('you must specify the imports.whosonfirst.sqlite_files array in your pelias.json');
+  process.exit(1);
+}
+
+// ensure required directory structure exists
+const metaDir = path.join(config.datapath, 'meta');
+const dataDir = path.join(config.datapath, 'data');
+fs.ensureDirSync(metaDir);
+fs.ensureDirSync(dataDir);
+
+// sql statements
+const sql = {
+  data: `SELECT id, body FROM geojson
+  WHERE id IN (
+    SELECT id
+    FROM ancestors
+    WHERE id = @wofid
+    OR ancestor_id = @wofid
+    GROUP BY id
+    ORDER BY id ASC
+  );`,
+  meta: `SELECT * FROM spr
+  WHERE id IN (
+    SELECT id
+    FROM ancestors
+    WHERE id = @wofid
+    OR ancestor_id = @wofid
+    GROUP BY id
+    ORDER BY id ASC
+  );`
+};
+
+// extract from a single db file
+function extract( dbpath ){
+  let targetWofId = config.importPlace;
+
+  // connect to sql db
+  let db = new Sqlite3( dbpath, { readonly: true } );
+
+  // extract all data to disk
+  for( let row of db.prepare(sql.data).iterate({ wofid: targetWofId }) ){
+    writeJson( row );
+  }
+
+  // write meta data to disk
+  writeMeta( db.prepare(sql.meta).all({ wofid: targetWofId }) );
+
+  // close connection
+  db.close();
+}
+
+// extract from all database files
+config.sqlite_files.forEach(file => { extract( file.filename ); });
+
+// write metadata to disk
+function writeMeta( rows ){
+  let placetypeCounts = {};
+
+  rows.forEach( row => {
+    let targetFile = path.join(metaDir, `${row.placetype}.csv`);
+
+    // first time we have seen a record for this placetype
+    if( !placetypeCounts.hasOwnProperty( row.placetype ) ){
+
+      // init the placetype counter
+      placetypeCounts[ row.placetype ] = 0;
+
+      // write csv header line
+      fs.writeFileSync( targetFile, Object.keys(row).join(',') + '\n', 'utf8' );
+    }
+
+    // write csv row
+    fs.appendFile( targetFile, Object.keys(row).map(key => row[key]).join(',') + '\n', 'utf8' );
+  });
+}
+
+// write json to disk
+function writeJson( row ){
+  let targetDir = path.join(dataDir, wofIdToPath(row.id).join(path.sep));
+  fs.ensureDir(targetDir, (error) => {
+    if( error ){ console.error(`error making directory ${targetDir}`); }
+    fs.writeFileSync( path.join(targetDir, `${row.id}.geojson`), row.body, 'utf8' );
+  });
+}
+
+// convert wofid integer to array of path components
+function wofIdToPath( id ){
+  let strId = id.toString();
+  let parts = [];
+  while( strId.length ){
+    let part = strId.substr(0, 3);
+    parts.push(part);
+    strId = strId.substr(3);
+  }
+  return parts;
+}


### PR DESCRIPTION
READY FOR REVIEW

this is a first pass at extracting data from the [wof sqlite databases](https://dist.whosonfirst.org/sqlite/) as an alternative to using the currently out-of-action WOF API.

I have tested this and it works great, we still need to add a little polish to it.

No additional properties are required in `pelias.json`, additionally `api_key` is no longer required.

The script also supports `postalcode`, `venue`, `constituency` and `intersection` placetypes where available.

npm `better-sqlite3` requires node 6+, is this an issue?
note: running this on node4 or less crashes node with the message `FATAL ERROR: v8::ToLocalChecked Empty MaybeLocal.`

```
"whosonfirst": {
  "datapath": "/tmp/wof",
  "importVenues": true,
  "importPostalcodes": true,
  "importConstituencies": true,
  "importIntersections": true,
  "importPlace": "101748799"
},
```

as usual, you can run the download with `npm run download`