### PR TITLE
index a version of postalcodes which doesnt include whitespace

### DIFF
--- a/src/peliasDocGenerators.js
+++ b/src/peliasDocGenerators.js
@@ -19,9 +19,16 @@ function assignField(hierarchyElement, wofDoc) {
     case 'continent':
     case 'ocean':
     case 'marinearea':
-    case 'postalcode':
       // the above place_types don't have abbrevations (yet)
       wofDoc.addParent(hierarchyElement.place_type, hierarchyElement.name, hierarchyElement.id.toString());
+      break;
+    case 'postalcode':
+      var sans_whitespace = (hierarchyElement.name||'').replace(/\s/g, '');
+      if (sans_whitespace !== hierarchyElement.name) {
+        wofDoc.addParent(hierarchyElement.place_type, hierarchyElement.name, hierarchyElement.id.toString(), sans_whitespace);
+      } else {
+        wofDoc.addParent(hierarchyElement.place_type, hierarchyElement.name, hierarchyElement.id.toString());
+      }
       break;
     case 'region':
       if (hierarchyElement.hasOwnProperty('abbreviation')) {
@@ -55,6 +62,14 @@ function setupDocument(record, hierarchy) {
 
   if (record.name) {
     wofDoc.setName('default', record.name);
+
+    // index a version of postcode which doesn't contain whitespace
+    if (record.place_type === 'postalcode' && typeof record.name === 'string') {
+      var sans_whitespace = record.name.replace(/\s/g, '');
+      if (sans_whitespace !== record.name) {
+        wofDoc.setNameAlias('default', sans_whitespace);
+      }
+    }
   }
   wofDoc.setCentroid({ lat: record.lat, lon: record.lon });
 

--- a/test/peliasDocGeneratorsTest.js
+++ b/test/peliasDocGeneratorsTest.js
@@ -41,6 +41,13 @@ tape('create', function(test) {
           .addParent( place_type, 'record name', '1')
       ];
 
+      // index a version of postcode which doesn't contain whitespace
+      if (place_type === 'postalcode'){
+        expected[0].setNameAlias('default', 'recordname')
+                   .clearParent(place_type)
+                   .addParent(place_type, 'record name', '1', 'recordname');
+      }
+
       var hierarchies_finder = function() {
         return [
           [


### PR DESCRIPTION
This PR checks to see if a postcode contains whitespace, if it does, then it indexes:

- an alias of the name without whitespace
- an abbreviation of the 'parent' postcode entry which contains no whitespace

Note: this will work great for directly searching for the WOF postcode record with a query such as 'E81DN' but would not apply to non-wof records until admin lookup is also patched, I will look at opening a PR there too and linking.