### PR TITLE
fix(postcode): Improve Null Island detection

### DIFF
--- a/src/components/isNotNullIslandRelated.js
+++ b/src/components/isNotNullIslandRelated.js
@@ -5,10 +5,14 @@ function isNullIsland(record) {
   return _.toNumber(record.id) === 1;
 }
 
+function isOnNullIsland(record) {
+  return (record.geom_latitude === '0.0' || record.geom_latitude === 0) &&
+         (record.geom_longitude === '0.0' || record.geom_longitude === 0);
+}
+
 function isPostalCodeOnNullIsland(record) {
   return record.placetype === 'postalcode' &&
-          record.geom_latitude === '0.0' &&
-          record.geom_longitude === '0.0';
+         isOnNullIsland(record);
 }
 
 module.exports.create = function create() {

--- a/test/components/isNotNullIslandRelated.js
+++ b/test/components/isNotNullIslandRelated.js
@@ -108,4 +108,16 @@ tape('recordHasName', (test) => {
 
   });
 
+  test.test('postalcode placetype records should not pass even if lat/lon is 0/0', (t) => {
+    const input = {
+      placetype: 'postalcode',
+      geom_latitude: 0,
+      geom_longitude: 0
+    };
+
+    test_stream([input], isNotNullIslandRelated.create(), (err, actual) => {
+      t.deepEqual(actual, [], 'should have returned true');
+      t.end();
+    });
+  });
 });


### PR DESCRIPTION
WOF records (especially postcodes) are often on Null Island for various reasons. We unfortunately can't make use of these records, even though they do have some useful information.

Our current Null Island detection was still letting some records through.

Connects https://github.com/whosonfirst-data/whosonfirst-data-postalcode-th/issues/1
Connects https://github.com/pelias/pelias/issues/692