### PR TITLE
feat(abbreviations): Use ISO-3166-1 alpha3 code from WOF records

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "csv-stream": "^0.2.0",
     "download-file-sync": "^1.0.4",
     "fs-extra": "^7.0.0",
-    "iso3166-1": "^0.3.0",
     "joi": "^13.1.2",
     "klaw-sync": "^4.0.0",
     "lodash": "^4.5.1",

--- a/src/components/extractFields.js
+++ b/src/components/extractFields.js
@@ -66,8 +66,8 @@ function getName(properties) {
 }
 
 function getAbbreviation(properties) {
-  if (properties['wof:placetype'] === 'country' && properties['wof:country']) {
-    return properties['wof:country'];
+  if (properties['wof:placetype'] === 'country' && properties['wof:country_alpha3']) {
+    return properties['wof:country_alpha3'];
   }
 
   // TODO: remove this section once WOF no-longer puts dependency abbreviations in `wof:country`

--- a/src/peliasDocGenerators.js
+++ b/src/peliasDocGenerators.js
@@ -1,6 +1,5 @@
 var through2 = require('through2');
 var _ = require('lodash');
-var iso3166 = require('iso3166-1');
 
 var Document = require('pelias-model').Document;
 
@@ -32,16 +31,12 @@ function assignField(hierarchyElement, wofDoc) {
       break;
     case 'dependency':
     case 'country':
-      // this is country or dependency, so lookup and set the iso3 from abbreviation
-      if (iso3166.is2(hierarchyElement.abbreviation)) {
-        var iso3 = iso3166.to3(hierarchyElement.abbreviation);
-
-        wofDoc.addParent(hierarchyElement.place_type, hierarchyElement.name, hierarchyElement.id.toString(), iso3);
-
+      // this is country or dependency, so set the ISO-3166-1 alpha3 code from abbreviation
+      if (hierarchyElement.abbreviation) {
+        wofDoc.addParent(hierarchyElement.place_type, hierarchyElement.name, hierarchyElement.id.toString(), hierarchyElement.abbreviation);
       } else {
         // there's no known abbreviation
         wofDoc.addParent(hierarchyElement.place_type, hierarchyElement.name, hierarchyElement.id.toString());
-
       }
 
       break;

--- a/test/components/extractFieldsTest.js
+++ b/test/components/extractFieldsTest.js
@@ -569,14 +569,14 @@ tape('readStreamComponents', function(test) {
     });
   });
 
-  test.test('wof:placetype=country should use wof:country value for abbreviation', function(t) {
+  test.test('wof:placetype=country should use wof:country_alpha3 value for abbreviation', function(t) {
     var input = [
       {
         id: 12345,
         properties: {
           'wof:name': 'wof:name value',
           'wof:placetype': 'country',
-          'wof:country': 'XY',
+          'wof:country_alpha3': 'XYZ',
           'wof:abbreviation': 'YZ'
         }
       }
@@ -592,7 +592,7 @@ tape('readStreamComponents', function(test) {
         population: undefined,
         popularity: undefined,
         bounding_box: undefined,
-        abbreviation: 'XY',
+        abbreviation: 'XYZ',
         hierarchies: [
           {
             'country_id': 12345
@@ -721,6 +721,45 @@ tape('readStreamComponents', function(test) {
       t.end();
     });
 
+  });
+
+  test.test('wof:placetype=country should use wof:country_alpha3 value for abbreviation if present', function(t) {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:placetype': 'country',
+          'wof:country': 'XY',
+          'wof:country_alpha3': 'XYZ',
+          'wof:abbreviation': 'YZ'
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'wof:name value',
+        place_type: 'country',
+        lat: undefined,
+        lon: undefined,
+        population: undefined,
+        popularity: undefined,
+        bounding_box: undefined,
+        abbreviation: 'XYZ',
+        hierarchies: [
+          {
+            'country_id': 12345
+          }
+        ]
+      }
+    ];
+
+    test_stream(input, extractFields.create(), function(err, actual) {
+      t.deepEqual(actual, expected, 'wof:country_alpha3 is used for abbreviation');
+      t.end();
+    });
   });
 
   test.test('wof:placetype=country should use wof:abbreviation value for abbreviation when wof:country is undefined', function(t) {

--- a/test/peliasDocGeneratorsTest.js
+++ b/test/peliasDocGeneratorsTest.js
@@ -104,7 +104,9 @@ tape('create', function(test) {
 
   });
 
-  test.test('dependency with unknown abbreviation should not set', function(t) {
+  test.test('dependency trusts even invalid WOF alpha3 abbreviation', function(t) {
+    // trust that WOF ISO-3166-1 alpha3 abbreviations are valid, to avoid having to pull in
+    // an ISO-3166-1 library
     var wofRecords = {
       1: {
         id: 1,
@@ -126,7 +128,7 @@ tape('create', function(test) {
       new Document( 'whosonfirst', 'dependency', '1')
         .setName('default', 'record name')
         .setCentroid({ lat: 12.121212, lon: 21.212121 })
-        .addParent( 'dependency', 'record name', '1')
+        .addParent( 'dependency', 'record name', '1', 'XY')
     ];
 
     var hierarchies_finder = function() {
@@ -152,7 +154,7 @@ tape('create', function(test) {
       1: {
         id: 1,
         name: 'record name',
-        abbreviation: 'PR',
+        abbreviation: 'PRI',
         lat: 12.121212,
         lon: 21.212121,
         place_type: 'dependency'
@@ -195,7 +197,7 @@ tape('create', function(test) {
       1: {
         id: 1,
         name: 'record name',
-        abbreviation: 'FR',
+        abbreviation: 'FRA',
         lat: 12.121212,
         lon: 21.212121,
         place_type: 'country'
@@ -349,7 +351,7 @@ tape('create', function(test) {
         lat: 12.121212,
         lon: 21.212121,
         place_type: 'country',
-        abbreviation: 'US',
+        abbreviation: 'USA',
         population: undefined
       }
     };
@@ -392,7 +394,7 @@ tape('create', function(test) {
         lat: 12.121212,
         lon: 21.212121,
         place_type: 'country',
-        abbreviation: 'US',
+        abbreviation: 'USA',
         population: 98765
       }
     };
@@ -436,7 +438,7 @@ tape('create', function(test) {
         lat: 12.121212,
         lon: 21.212121,
         place_type: 'country',
-        abbreviation: 'US',
+        abbreviation: 'USA',
         popularity: undefined
       }
     };
@@ -479,7 +481,7 @@ tape('create', function(test) {
         lat: 12.121212,
         lon: 21.212121,
         place_type: 'country',
-        abbreviation: 'US',
+        abbreviation: 'USA',
         popularity: 87654
       }
     };


### PR DESCRIPTION
Pelias requires an ISO-3166-1 alpha3 country code on all country records. Currently, we use the `wof:country` field, which contains an alpha2 code, and convert to alpha3 codes. This PR replaces that approach and uses the `wof:country_alpha3` field, if present, to set the corresponding field on Pelias country records.

This allows us to remove the troublesome (see https://github.com/pelias/api/issues/1179) iso3166-1 NPM package.

One implication of the change is that it does mean we are trusting the data in WOF to be correct.

My read of the discussions in https://github.com/whosonfirst-data/whosonfirst-data/pull/823, https://github.com/whosonfirst-data/whosonfirst-data/pull/1055, and other related WOF issues is that this is the right field going forward. However, we can easily change it.

@nvkelso @stepps00, does this seem like the right field to use for country abbreviations?