### PR TITLE
feat(abbreviations): use wof:abbreviation for dependencies if available

### DIFF
--- a/src/components/extractFields.js
+++ b/src/components/extractFields.js
@@ -65,14 +65,16 @@ function getName(properties) {
   }
 }
 
-function isDependencyOrCountry(placetype) {
-  return placetype === 'dependency' || placetype === 'country';
-}
-
 function getAbbreviation(properties) {
-  if (isDependencyOrCountry(properties['wof:placetype']) && properties['wof:country']) {
+  if (properties['wof:placetype'] === 'country' && properties['wof:country']) {
     return properties['wof:country'];
   }
+
+  // TODO: remove this section once WOF no-longer puts dependency abbreviations in `wof:country`
+  if (properties['wof:placetype'] === 'dependency') {
+    return properties['wof:abbreviation'] || properties['wof:country'];
+  }
+
   return properties['wof:abbreviation'];
 }
 

--- a/test/components/extractFieldsTest.js
+++ b/test/components/extractFieldsTest.js
@@ -533,15 +533,15 @@ tape('readStreamComponents', function(test) {
 
   });
 
-  test.test('wof:placetype=dependency should use wof:country value for abbreviation', function(t) {
+  test.test('wof:placetype=dependency should use wof:abbreviation value for abbreviation if present', function(t) {
     var input = [
       {
         id: 12345,
         properties: {
           'wof:name': 'wof:name value',
           'wof:placetype': 'dependency',
-          'wof:country': 'XY',
-          'wof:abbreviation': 'YZ'
+          'wof:country': 'value from wof:country',
+          'wof:abbreviation': 'value from wof:abbreviation'
         }
       }
     ];
@@ -556,7 +556,44 @@ tape('readStreamComponents', function(test) {
         population: undefined,
         popularity: undefined,
         bounding_box: undefined,
-        abbreviation: 'XY',
+        abbreviation: 'value from wof:abbreviation',
+        hierarchies: [
+          {
+            'dependency_id': 12345
+          }
+        ]
+      }
+    ];
+
+    test_stream(input, extractFields.create(), function(err, actual) {
+      t.deepEqual(actual, expected, 'wof:country is used for abbreviation');
+      t.end();
+    });
+  });
+
+  test.test('wof:placetype=dependency should use wof:country value for abbreviation if wof:abbreviation not present', function(t) {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:placetype': 'dependency',
+          'wof:country': 'value from wof:country',
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'wof:name value',
+        place_type: 'dependency',
+        lat: undefined,
+        lon: undefined,
+        population: undefined,
+        popularity: undefined,
+        bounding_box: undefined,
+        abbreviation: 'value from wof:country',
         hierarchies: [
           {
             'dependency_id': 12345


### PR DESCRIPTION
This is a backwards-compatible version of https://github.com/pelias/whosonfirst/pull/273 which allows us to handle the upcoming switch from storing dependency abbreviations in the `wof:country` field to `wof:abbreviation` (see https://github.com/whosonfirst-data/whosonfirst-data/pull/823)

It should be safe to merge now and will do the right thing once WOF data is updated.

Supersedes https://github.com/pelias/whosonfirst/pull/273