### PR TITLE
Update README banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+>This repository is part of the [Pelias](https://github.com/pelias/pelias)
+>project. Pelias is an open-source, open-data geocoder originally sponsored by
+>[Mapzen](https://www.mapzen.com/). Our official user documentation is
+>[here](https://github.com/pelias/documentation).
+
 # Pelias Who's on First Data Importer
 
 [![Greenkeeper badge](https://badges.greenkeeper.io/pelias/whosonfirst.svg)](https://greenkeeper.io/)


### PR DESCRIPTION
The standard banner we have used at the top of all Pelias repositories is out of date, as it still references Mapzen as the current creator of Pelias, and links to Mapzen documentation.

Connects https://github.com/pelias/pelias/issues/702