### PR TITLE
Fix for WOF bundle issues

### DIFF
--- a/src/bundleList.js
+++ b/src/bundleList.js
@@ -107,7 +107,10 @@ function getBundleList(callback) {
 
   rl.on('line', (line) => {
 
-    sortBundleByBuckets(roles, line, bundleBuckets);
+    const parts = line.split(' ');
+    const record = parts[parts.length - 1];
+
+    sortBundleByBuckets(roles, record, bundleBuckets);
 
   }).on('close', () => {
 

--- a/test/bundleList.js
+++ b/test/bundleList.js
@@ -85,7 +85,7 @@ tape('bundlesList tests', (test) => {
     const bundles = proxyquire('../src/bundleList', { 'pelias-config': config });
 
     bundles.generateBundleList((err, bundlesList) => {
-      t.assert(bundlesList.includes('wof-venue-us-ca-latest-bundle.tar.bz2'), 'venue bundle for regions are included');
+      t.assert(bundlesList.includes('whosonfirst-data-venue-us-ca-latest.tar.bz2'), 'venue bundle for regions are included');
       fs.removeSync('foo');
       t.end();
     });

--- a/utils/download_data_all.js
+++ b/utils/download_data_all.js
@@ -27,7 +27,7 @@ function download(callback) {
   // 3.) move the meta file to the meta files directory
   function generateCommand(bundle, directory) {
     const csvFilename = bundle.replace(/-\d{8}T\d{6}-/, '-latest-') // support timestamped downloads
-                              .replace('-bundle.tar.bz2', '.csv');
+                              .replace('.tar.bz2', '.csv');
 
     return 'curl https://dist.whosonfirst.org/bundles/' + bundle + ' | tar -xj --strip-components=1 --exclude=README.txt -C ' +
       directory + ' && mv ' + path.join(directory, csvFilename) + ' ' + path.join(directory, 'meta');


### PR DESCRIPTION
This PR is a minimal set of changes to restore download functionality in the wake of some recent Who's on First changes.

These changes are:
- **temporarily** the `index.txt` bundle file will contain several space-delimited fields per line, whereas this importer previously expected the only item per line to be the name of a bundle for download
- The format of the bundle names has changed. This shouldn't have been an issue, but at least one place in our code assumed a certain format (and one test has a hardcoded name, which is less of a problem)