### PR TITLE
fix(sqlite): Update metadata filename when writing

### DIFF
--- a/bin/units
+++ b/bin/units
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -euo pipefail
+
+node test/test.js | npx tap-dot

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "start": "node import.js",
     "download": "node ./utils/download_data.js",
-    "test": "node test/test | tap-dot",
+    "test": "./bin/units",
     "lint": "jshint .",
     "validate": "npm ls",
     "travis": "npm run test"

--- a/test/components/metadataStream.js
+++ b/test/components/metadataStream.js
@@ -12,7 +12,7 @@ tape('metadataStream tests', (test) => {
 
       // write some data to a file that will be read
       fs.writeFileSync(
-        path.join(temp_dir, 'meta', 'wof-my_placetype-latest.csv'),
+        path.join(temp_dir, 'meta', 'whosonfirst-data-my_placetype-latest.csv'),
         'some metadata');
 
       const metadataStream = require('../../src/components/metadataStream')(temp_dir);

--- a/test/readStreamTest.js
+++ b/test/readStreamTest.js
@@ -17,7 +17,7 @@ tape('readStream', (test) => {
       fs.mkdirSync(path.join(temp_dir, 'meta'));
       fs.mkdirSync(path.join(temp_dir, 'data'));
 
-      fs.writeFileSync(path.join(temp_dir, 'meta', 'wof-type1-latest.csv'), 'id,path\n123,123.geojson\n');
+      fs.writeFileSync(path.join(temp_dir, 'meta', 'whosonfirst-data-type1-latest.csv'), 'id,path\n123,123.geojson\n');
       fs.writeFileSync(path.join(temp_dir, 'data', '123.geojson'), JSON.stringify({
         id: 123,
         properties: {
@@ -33,7 +33,7 @@ tape('readStream', (test) => {
       }));
 
       // write out second meta and data files
-      fs.writeFileSync(path.join(temp_dir, 'meta', 'wof-type2-latest.csv'), 'id,path\n456,456.geojson\n');
+      fs.writeFileSync(path.join(temp_dir, 'meta', 'whosonfirst-data-type2-latest.csv'), 'id,path\n456,456.geojson\n');
       fs.writeFileSync(path.join(temp_dir, 'data', '456.geojson'), JSON.stringify({
         id: 456,
         properties: {
@@ -49,7 +49,7 @@ tape('readStream', (test) => {
       // write out third meta and data files that are ignored
       // it will be ignored since 'type3' is not passed as a supported type
       // this shows that types are supported instead of all files being globbed
-      fs.writeFileSync(path.join(temp_dir, 'meta', 'wof-type3-latest.csv'), 'id,path\n789,789.geojson\n');
+      fs.writeFileSync(path.join(temp_dir, 'meta', 'whosonfirst-data-type3-latest.csv'), 'id,path\n789,789.geojson\n');
       fs.writeFileSync(path.join(temp_dir, 'data', '789.geojson'), JSON.stringify({
         id: 789,
         properties: {
@@ -67,7 +67,8 @@ tape('readStream', (test) => {
       };
 
       const wofAdminRecords = {};
-      const stream = readStream.create(wofConfig, ['wof-type1-latest.csv', 'wof-type2-latest.csv'], wofAdminRecords);
+      const filenames = ['whosonfirst-data-type1-latest.csv', 'whosonfirst-data-type2-latest.csv'];
+      const stream = readStream.create(wofConfig, filenames, wofAdminRecords);
 
       stream.on('finish', _ => {
         temp.cleanupSync();
@@ -104,8 +105,8 @@ tape('readStream', (test) => {
         });
 
         t.deepEquals(logger.getInfoMessages(), [
-          `Loading wof-type1-latest.csv records from ${temp_dir}/meta`,
-          `Loading wof-type2-latest.csv records from ${temp_dir}/meta`
+          `Loading whosonfirst-data-type1-latest.csv records from ${temp_dir}/meta`,
+          `Loading whosonfirst-data-type2-latest.csv records from ${temp_dir}/meta`
         ]);
         t.end();
 

--- a/utils/sqlite_common.js
+++ b/utils/sqlite_common.js
@@ -14,7 +14,7 @@ module.exports.MetaDataFiles = function MetaDataFiles( metaDir ){
 
       // create write stream
       streams[row.placetype] = fs.createWriteStream(
-        path.join( metaDir, `wof-${row.placetype}-latest.csv` )
+        path.join( metaDir, `whosonfirst-data-${row.placetype}-latest.csv` )
       );
 
       // init stats


### PR DESCRIPTION
After https://github.com/pelias/whosonfirst/pull/389 and https://github.com/pelias/wof-admin-lookup/pull/229, WOF metafiles are expected to follow the pattern `whosonfirst-data-${layer}-latest.csv`. We missed the code that creates fake metafiles after exporting from SQLite.

Due to the way we were running our tests, there was a unit test to catch this error, but it was **not properly failing the tests** (see https://github.com/pelias/api/pull/500 for a similar situation). This has been corrected by using a script to run the tests with the `pipefail` option set.