### PR TITLE
Support read only root filesystem when running in Docker containers

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec node ./utils/download_data.js

--- a/bin/start
+++ b/bin/start
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec node import.js

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "description": "Importer for Who's on First",
   "main": "index.js",
   "scripts": {
-    "start": "node import.js",
+    "start": "./bin/start",
     "download": "node ./utils/download_data.js",
     "test": "./bin/units",
     "lint": "jshint .",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "main": "index.js",
   "scripts": {
     "start": "./bin/start",
-    "download": "node ./utils/download_data.js",
+    "download": "./bin/download",
     "test": "./bin/units",
     "lint": "jshint .",
     "validate": "npm ls",


### PR DESCRIPTION
By using a dedicated start script instead of `npm start` when running Docker images, we can avoid issues with passing signals through to the underlying processes.

This also avoids issues with `npm` requiring write permissions to the root filesystem.

Connects https://github.com/pelias/pelias/issues/745