### PR TITLE
feat(abbreviations): handle changing abbreviation fields

### DIFF
--- a/src/components/extractFields.js
+++ b/src/components/extractFields.js
@@ -65,15 +65,17 @@ function getName(properties) {
   }
 }
 
-function isDependencyOrCountry(placetype) {
-  return placetype === 'dependency' || placetype === 'country';
-}
-
 function getAbbreviation(properties) {
-  if (isDependencyOrCountry(properties['wof:placetype']) && properties['wof:country']) {
+  if (properties['wof:placetype'] === 'country' && properties['wof:country']) {
     return properties['wof:country'];
   }
-  return properties['wof:abbreviation'];
+
+  // TODO: remove this section once WOF no-longer puts dependency abbreviations in `wof:country`
+  if (properties['wof:placetype'] === 'dependency') {
+    return properties['wof:shortcode'] || properties['wof:abbreviation'] || properties['wof:country'];
+  }
+
+  return properties['wof:shortcode'] || properties['wof:abbreviation'];
 }
 
 function getHierarchies(id, properties) {

--- a/test/components/extractFieldsTest.js
+++ b/test/components/extractFieldsTest.js
@@ -494,6 +494,81 @@ tape('readStreamComponents', function(test) {
 
   });
 
+  test.test('wof:placetype=locality (general abbreviation case) should use wof:shortcode over wof:abbreviation', function(t) {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:placetype': 'locality',
+          'wof:abbreviation': 'undesired',
+          'wof:shortcode': 'desired'
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'wof:name value',
+        place_type: 'locality',
+        lat: undefined,
+        lon: undefined,
+        population: undefined,
+        popularity: undefined,
+        bounding_box: undefined,
+        abbreviation: 'desired',
+        hierarchies: [
+          {
+            'locality_id': 12345
+          }
+        ]
+      }
+    ];
+
+    test_stream(input, extractFields.create(), function(err, actual) {
+      t.deepEqual(actual, expected, 'wof:shortcode is used for abbreviation');
+      t.end();
+    });
+  });
+
+  test.test('wof:placetype=locality (general abbreviation case) should use wof:abbreviation if wof:shortcode not present', function(t) {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:placetype': 'locality',
+          'wof:abbreviation': 'desired'
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'wof:name value',
+        place_type: 'locality',
+        lat: undefined,
+        lon: undefined,
+        population: undefined,
+        popularity: undefined,
+        bounding_box: undefined,
+        abbreviation: 'desired',
+        hierarchies: [
+          {
+            'locality_id': 12345
+          }
+        ]
+      }
+    ];
+
+    test_stream(input, extractFields.create(), function(err, actual) {
+      t.deepEqual(actual, expected, 'wof:shortcode is used for abbreviation');
+      t.end();
+    });
+  });
+
   test.test('wof:placetype=country should use wof:country value for abbreviation', function(t) {
     var input = [
       {
@@ -533,15 +608,16 @@ tape('readStreamComponents', function(test) {
 
   });
 
-  test.test('wof:placetype=dependency should use wof:country value for abbreviation', function(t) {
+  test.test('wof:placetype=dependency should use wof:shortcode value for abbreviation if present', function(t) {
     var input = [
       {
         id: 12345,
         properties: {
           'wof:name': 'wof:name value',
           'wof:placetype': 'dependency',
-          'wof:country': 'XY',
-          'wof:abbreviation': 'YZ'
+          'wof:country': 'value from wof:country',
+          'wof:abbreviation': 'value from wof:abbreviation',
+          'wof:shortcode': 'value from wof:shortcode'
         }
       }
     ];
@@ -556,7 +632,82 @@ tape('readStreamComponents', function(test) {
         population: undefined,
         popularity: undefined,
         bounding_box: undefined,
-        abbreviation: 'XY',
+        abbreviation: 'value from wof:shortcode',
+        hierarchies: [
+          {
+            'dependency_id': 12345
+          }
+        ]
+      }
+    ];
+
+    test_stream(input, extractFields.create(), function(err, actual) {
+      t.deepEqual(actual, expected, 'wof:shortcode is used for abbreviation');
+      t.end();
+    });
+  });
+
+  test.test('wof:placetype=dependency should use wof:abbreviation value for abbreviation if wof:shortcode not present', function(t) {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:placetype': 'dependency',
+          'wof:country': 'value from wof:country',
+          'wof:abbreviation': 'value from wof:abbreviation'
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'wof:name value',
+        place_type: 'dependency',
+        lat: undefined,
+        lon: undefined,
+        population: undefined,
+        popularity: undefined,
+        bounding_box: undefined,
+        abbreviation: 'value from wof:abbreviation',
+        hierarchies: [
+          {
+            'dependency_id': 12345
+          }
+        ]
+      }
+    ];
+
+    test_stream(input, extractFields.create(), function(err, actual) {
+      t.deepEqual(actual, expected, 'wof:abbreviation is used for abbreviation');
+      t.end();
+    });
+  });
+
+  test.test('wof:placetype=dependency should use wof:country for abbreviation if wof:shortcode/wof:abbreviation not present', function(t) {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:placetype': 'dependency',
+          'wof:country': 'value from wof:country',
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'wof:name value',
+        place_type: 'dependency',
+        lat: undefined,
+        lon: undefined,
+        population: undefined,
+        popularity: undefined,
+        bounding_box: undefined,
+        abbreviation: 'value from wof:country',
         hierarchies: [
           {
             'dependency_id': 12345


### PR DESCRIPTION
Several abbreviation fields have changed or will change over time in WOF.

1.) `wof:shortcode` just replaced `wof:abbreviation`
2.) for dependency records, `wof:shortcode` will replace `wof:country`

This change allows us to handle both of those changing fields in a backwards compatible way, by supporting the older field but prioritizing the newer ones.

We should later come in and remove the logic to refer to the older values once we're sure they're no longer used and enough time has passed that most people will have updated their copy of WOF data.

Supersedes https://github.com/pelias/whosonfirst/pull/273
Supersedes https://github.com/pelias/whosonfirst/pull/375
Fixes https://github.com/pelias/whosonfirst/issues/398
Fixes https://github.com/pelias/pelias/issues/645
Connects https://github.com/whosonfirst/whosonfirst-properties/issues/78