### PR TITLE
feat(download): Allow configuring download count

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The following configuration options are supported by this importer.
 | `imports.whosonfirst.importVenues` | no | false | set to `true` to include venues in the data download and import process |
 | `imports.whosonfirst.importPlace` | no | | set to a WOF id (number or string) indicating the region of interest, only data pertaining to that place shall be downloaded. Use the WOF [spelunker tool](https://spelunker.whosonfirst.org) search for an ID of a place. |
 | `imports.whosonfirst.missingFilesAreFatal` | no | false | set to `true` for missing files from [Who's on First bundles](https://dist.whosonfirst.org/bundles/) to stop the import process |
+| `imports.whosonfirst.maxDownloads` | no | 4 | the maximum number of files to download simultaneously. Higher values can be faster, but can also cause donwload errors |
 
 ## Downloading the Data
 

--- a/utils/download_data_all.js
+++ b/utils/download_data_all.js
@@ -1,4 +1,3 @@
-
 const child_process = require('child_process');
 const async = require('async');
 const fs = require('fs-extra');
@@ -14,10 +13,12 @@ function download(callback) {
   fs.ensureDirSync(path.join(config.imports.whosonfirst.datapath, 'meta'));
 
   // download one bundle for every other CPU (tar and bzip2 can both max out one core)
-  // (but not more than 4, to keep things from getting too intense)
+  // (the maximum is configurable, to keep things from getting too intense, and defaults to 4)
   //lower this number to make the downloader more CPU friendly
   //raise this number to (possibly) make it faster
-  const simultaneousDownloads = Math.max(4, Math.min(1, os.cpus().length / 2));
+  const maxSimultaneousDownloads = config.get('imports.whosonfirst.maxDownloads') || 4;
+  const cpuCount = os.cpus().length;
+  const simultaneousDownloads = Math.max(maxSimultaneousDownloads, Math.min(1, cpuCount / 2));
 
   // generate a shell command that does the following:
   // 1.) use curl to download the bundle, piping directly to tar (this avoids the


### PR DESCRIPTION
This has been found to be necessary when downloading on slow network connections or to slow disks (such as EFS).

The combination of maxing out network bandwidth, high CPU usage while extracting archives, and high disk usage writing many small files seems to be capable of causing errors on many systems.