### PR TITLE
Support custom download location

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The following configuration options are supported by this importer.
 | `imports.whosonfirst.importPlace` | no | | set to a WOF id (number or string) indicating the region of interest, only data pertaining to that place shall be downloaded. Use the WOF [spelunker tool](https://spelunker.whosonfirst.org) search for an ID of a place. |
 | `imports.whosonfirst.missingFilesAreFatal` | no | false | set to `true` for missing files from [Who's on First bundles](https://dist.whosonfirst.org/bundles/) to stop the import process |
 | `imports.whosonfirst.maxDownloads` | no | 4 | the maximum number of files to download simultaneously. Higher values can be faster, but can also cause donwload errors |
+| `imports.whosonfirst.dataHost` | no | `https://dist.whosonfirst.org/` | The location to download Who's on First data from. Changing this can be useful to use custom data, pin data to a specific date, etc |
 
 ## Downloading the Data
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "node-version-checker": "^2.0.0",
     "parallel-transform": "^1.1.0",
     "pelias-blacklist-stream": "^1.0.0",
-    "pelias-config": "^3.3.0",
+    "pelias-config": "^3.8.1",
     "pelias-dbclient": "^2.5.6",
     "pelias-logger": "^1.2.1",
     "pelias-model": "^5.5.2",

--- a/schema.js
+++ b/schema.js
@@ -15,6 +15,7 @@ const Joi = require('joi');
 module.exports = Joi.object().keys({
   imports: Joi.object().keys({
     whosonfirst: Joi.object().keys({
+      dataHost: Joi.string(),
       datapath: Joi.string(),
       importPlace: [
         Joi.number().integer(),

--- a/src/bundleList.js
+++ b/src/bundleList.js
@@ -1,4 +1,3 @@
-
 const readline = require('readline');
 const fs = require('fs-extra');
 const path = require('path');
@@ -60,8 +59,9 @@ function getPlacetypes() {
 }
 
 function ensureBundleIndexExists(metaDataPath) {
+  const wofDataHost = peliasConfig.get('imports.whosonfirst.dataHost') || 'https://dist.whosonfirst.org';
   const bundleIndexFile = path.join(metaDataPath, 'whosonfirst_bundle_index.txt');
-  const bundleIndexUrl = 'https://dist.whosonfirst.org/bundles/index.txt';
+  const bundleIndexUrl = `${wofDataHost}/bundles/index.txt`;
 
   //ensure required directory structure exists
   fs.ensureDirSync(metaDataPath);

--- a/test/bundleList.js
+++ b/test/bundleList.js
@@ -1,8 +1,8 @@
-
 const tape = require('tape');
 const proxyquire = require('proxyquire');
 const fs = require('fs-extra');
 const _ = require('lodash');
+const peliasConfig = require('pelias-config');
 
 proxyquire.noPreserveCache();
 proxyquire.noCallThru();
@@ -38,7 +38,7 @@ tape('bundlesList tests', (test) => {
 
     const config = {
       generate: () => {
-        return {
+        return peliasConfig.generateCustom({
           imports: {
             whosonfirst: {
               datapath: 'foo',
@@ -46,7 +46,7 @@ tape('bundlesList tests', (test) => {
               importPostalcodes: true
             }
           }
-        };
+        });
       }
     };
 
@@ -70,7 +70,7 @@ tape('bundlesList tests', (test) => {
   test.test('region venue bundles', (t) => {
     const config = {
       generate: () => {
-        return {
+        return peliasConfig.generateCustom({
           imports: {
             whosonfirst: {
               datapath: 'foo',
@@ -78,7 +78,7 @@ tape('bundlesList tests', (test) => {
               importPostalcodes: true
             }
           }
-        };
+        });
       }
     };
 
@@ -95,13 +95,13 @@ tape('bundlesList tests', (test) => {
 
     const config = {
       generate: () => {
-        return {
+        return peliasConfig.generateCustom({
           imports: {
             whosonfirst: {
               datapath: 'foo'
             }
           }
-        };
+        });
       }
     };
 
@@ -135,7 +135,7 @@ tape('bundlesList tests', (test) => {
 
     const config = {
       generate: () => {
-        return {
+        return peliasConfig.generateCustom({
           imports: {
             whosonfirst: {
               datapath: 'foo',
@@ -143,7 +143,7 @@ tape('bundlesList tests', (test) => {
               importPostalcodes: true
             }
           }
-        };
+        });
       }
     };
 

--- a/utils/download_data_all.js
+++ b/utils/download_data_all.js
@@ -8,6 +8,8 @@ const path = require('path');
 const bundles = require('../src/bundleList');
 const config = require( 'pelias-config' ).generate(require('../schema'));
 
+const wofDataHost = config.get('imports.whosonfirst.dataHost') || 'https://dist.whosonfirst.org';
+
 function download(callback) {
   //ensure required directory structure exists
   fs.ensureDirSync(path.join(config.imports.whosonfirst.datapath, 'meta'));
@@ -30,8 +32,8 @@ function download(callback) {
     const csvFilename = bundle.replace(/-\d{8}T\d{6}-/, '-latest-') // support timestamped downloads
                               .replace('.tar.bz2', '.csv');
 
-    return 'curl https://dist.whosonfirst.org/bundles/' + bundle + ' | tar -xj --strip-components=1 --exclude=README.txt -C ' +
-      directory + ' && mv ' + path.join(directory, csvFilename) + ' ' + path.join(directory, 'meta');
+    return `curl ${wofDataHost}/bundles/${bundle} | tar -xj --strip-components=1 --exclude=README.txt -C ` +
+      `${directory} && mv ${path.join(directory, csvFilename)} ${path.join(directory, 'meta')}`;
   }
 
   bundles.generateBundleList((err, bundlesToDownload) => {


### PR DESCRIPTION
This PR adds support for downloading WOF data from a custom location.

This might be useful to:
- support custom modifications to WOF data
- pin WOF data to a particular version
- provide backup hosting for WOF data