### PR TITLE
Supports for WOF SQLite database

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The following configuration options are supported by this importer.
 | `imports.whosonfirst.missingFilesAreFatal` | no | false | set to `true` for missing files from [Who's on First bundles](https://dist.whosonfirst.org/bundles/) to stop the import process |
 | `imports.whosonfirst.maxDownloads` | no | 4 | the maximum number of files to download simultaneously. Higher values can be faster, but can also cause donwload errors |
 | `imports.whosonfirst.dataHost` | no | `https://dist.whosonfirst.org/` | The location to download Who's on First data from. Changing this can be useful to use custom data, pin data to a specific date, etc |
+| `imports.whosonfirst.sqlite` | no | false | Set to `true` to use Who's on First SQLite databases instead of GeoJSON bundles. |
 
 ## Downloading the Data
 

--- a/bin/sqlite-clean
+++ b/bin/sqlite-clean
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec node ./utils/sqlite_clean.js

--- a/bin/start
+++ b/bin/start
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-exec node import.js
+exec node --max_old_space_size=4096 import.js

--- a/import.js
+++ b/import.js
@@ -22,11 +22,12 @@ bundles.generateBundleList((err, bundlesToImport) => {
     throw new Error(err.message);
   }
 
-  const bundlesMetaFiles = bundlesToImport.map( (bundle) => { return bundle.replace('.tar.bz2', '.csv'); });
+  // This can be either csv or db files, the read stream module will do the job
+  const bundlesFiles = bundlesToImport.map( (bundle) => { return bundle.replace('.tar.bz2', '.csv'); });
 
   const readStream = readStreamModule.create(
     peliasConfig.imports.whosonfirst,
-    bundlesMetaFiles,
+    bundlesFiles,
     wofAdminRecords);
 
   // how to convert WOF records to Pelias Documents

--- a/index.js
+++ b/index.js
@@ -7,5 +7,6 @@ module.exports = {
   recordHasIdAndProperties: require('./src/components/recordHasIdAndProperties').create,
   recordHasName: require('./src/components/recordHasName').create,
   conformsTo: require('./src/components/conformsTo').create,
-  sqliteStream: require('./src/components/sqliteStream')
+  SQLiteStream: require('./src/components/sqliteStream'),
+  toJSONStream: require('./src/components/toJSONStream').create
 };

--- a/index.js
+++ b/index.js
@@ -6,5 +6,6 @@ module.exports = {
   parseMetaFiles: require('./src/components/parseMetaFiles').create,
   recordHasIdAndProperties: require('./src/components/recordHasIdAndProperties').create,
   recordHasName: require('./src/components/recordHasName').create,
-  conformsTo: require('./src/components/conformsTo').create
+  conformsTo: require('./src/components/conformsTo').create,
+  sqliteStream: require('./src/components/sqliteStream')
 };

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "async": "^2.5.0",
     "better-sqlite3": "^4.1.0",
-    "combined-stream": "^1.0.5",
+    "combined-stream": "1.0.5",
     "csv-stream": "^0.2.0",
     "download-file-sync": "^1.0.4",
     "fs-extra": "^7.0.0",

--- a/schema.js
+++ b/schema.js
@@ -26,7 +26,8 @@ module.exports = Joi.object().keys({
       importConstituencies: Joi.boolean().default(false).truthy('yes').falsy('no').insensitive(true),
       importIntersections: Joi.boolean().default(false).truthy('yes').falsy('no').insensitive(true),
       missingFilesAreFatal: Joi.boolean().default(false).truthy('yes').falsy('no').insensitive(true),
-      maxDownloads: Joi.number().integer()
+      maxDownloads: Joi.number().integer(),
+      sqlite: Joi.boolean().default(false).truthy('yes').falsy('no').insensitive(true)
     }).requiredKeys('datapath').unknown(false)
   }).requiredKeys('whosonfirst').unknown(true)
 }).requiredKeys('imports').unknown(true);

--- a/src/bundleList.js
+++ b/src/bundleList.js
@@ -41,7 +41,7 @@ const venueRoles = [
   'venue'
 ];
 
-const SQLITE_REGEX = /whosonfirst-data-[a-z-]+.db/;
+const SQLITE_REGEX = /whosonfirst-data-[a-z0-9-]+.db/;
 
 function getPlacetypes() {
   let roles = hierarchyRoles;

--- a/src/bundleList.js
+++ b/src/bundleList.js
@@ -41,7 +41,7 @@ const venueRoles = [
   'venue'
 ];
 
-const SQLITE_REGEX = /whosonfirst-data-[a-z0-9-]+.db/;
+const SQLITE_REGEX = /whosonfirst-data-[a-z0-9-]+\.db$/;
 
 function getPlacetypes() {
   let roles = hierarchyRoles;

--- a/src/bundleList.js
+++ b/src/bundleList.js
@@ -41,6 +41,7 @@ const venueRoles = [
   'venue'
 ];
 
+const SQLITE_REGEX = /whosonfirst-data-[a-z-]+.db/;
 
 function getPlacetypes() {
   let roles = hierarchyRoles;
@@ -121,6 +122,25 @@ function getBundleList(callback) {
   });
 }
 
+function getDBList(callback) {
+  const databasesPath = path.join(peliasConfig.imports.whosonfirst.datapath, 'sqlite');
+  //ensure required directory structure exists
+  fs.ensureDirSync(databasesPath);
+  const dbList = fs.readdirSync(databasesPath).filter(d => SQLITE_REGEX.test(d));
+
+  if (_.isEmpty(dbList)) {
+    return callback(`No database found in ${databasesPath}`);
+  }
+  callback(null, dbList);
+}
+
+function getList(callback) {
+  if (peliasConfig.imports.whosonfirst.sqlite) {
+    return getDBList(callback);
+  }
+  getBundleList(callback);
+}
+
 function initBundleBuckets(roles) {
   const bundleBuckets = {};
   roles.forEach( (role) => {
@@ -151,4 +171,4 @@ function combineBundleBuckets(roles, bundleBuckets) {
 }
 
 module.exports.getPlacetypes = getPlacetypes;
-module.exports.generateBundleList = getBundleList;
+module.exports.generateBundleList = getList;

--- a/src/components/sqliteStream.js
+++ b/src/components/sqliteStream.js
@@ -6,14 +6,45 @@ class SQLiteStream extends Readable {
     super({ objectMode: true, autoDestroy: true });
     this._db = new Sqlite3(dbPath, { readonly: true });
     this._iterator = this._db.prepare(sql).iterate();
+    this.on('end', () => {
+      this._db.close();
+    });
   }
 
   _read() {
     const elt = this._iterator.next();
-    if(!this.push(!elt.done && elt.value ? elt.value : null)) {
-      this._db.close();
-    }
+    this.push(!elt.done && elt.value ? elt.value : null);
   }
 }
 
+/**
+ * Filter deprecated, superseded and null island objects
+ */
+function findGeoJSON() {
+  return `
+SELECT geojson.id, geojson.body
+  FROM geojson JOIN spr
+  ON geojson.id = spr.id
+  WHERE
+    geojson.id != 1
+      AND
+    spr.is_deprecated = 0
+      AND
+    spr.is_superseded = 0
+      AND
+    (spr.latitude != 0 OR spr.longitude != 0)`;
+}
+
+/**
+ * Add filter and placetypes
+ */
+function findGeoJSONByPlacetype(placetypes) {
+  return findGeoJSON() + `
+      AND
+    spr.placetype IN ('${placetypes.join('\',\'')}')
+`;
+}
+
 module.exports = SQLiteStream;
+module.exports.findGeoJSON = findGeoJSON;
+module.exports.findGeoJSONByPlacetype = findGeoJSONByPlacetype;

--- a/src/components/sqliteStream.js
+++ b/src/components/sqliteStream.js
@@ -1,0 +1,19 @@
+const Readable = require('stream').Readable;
+const Sqlite3 = require('better-sqlite3');
+
+class SQLiteStream extends Readable {
+  constructor(dbPath, sql) {
+    super({ encoding: 'utf-8', autoDestroy: true });
+    this._db = new Sqlite3(dbPath, { readonly: true });
+    this._iterator = this._db.prepare(sql).iterate();
+  }
+
+  _read() {
+    const elt = this._iterator.next();
+    if(!this.push(!elt.done && elt.value ? elt.value.body : null)) {
+      this._db.close();
+    }
+  }
+}
+
+module.exports = SQLiteStream;

--- a/src/components/sqliteStream.js
+++ b/src/components/sqliteStream.js
@@ -41,7 +41,9 @@ SELECT geojson.id, geojson.body
  * Add filter and placetypes
  */
 function findGeoJSONByPlacetype(placetypes) {
-  placetypes = typeof placetypes === 'string' ? [placetypes] : placetypes;
+  if(!Array.isArray(placetypes)) {
+    placetypes = [ placetypes ];
+  }
   return findGeoJSON() + `
       AND
     spr.placetype IN ('${placetypes.join('\',\'')}')

--- a/src/components/sqliteStream.js
+++ b/src/components/sqliteStream.js
@@ -3,14 +3,14 @@ const Sqlite3 = require('better-sqlite3');
 
 class SQLiteStream extends Readable {
   constructor(dbPath, sql) {
-    super({ encoding: 'utf-8', autoDestroy: true });
+    super({ objectMode: true, autoDestroy: true });
     this._db = new Sqlite3(dbPath, { readonly: true });
     this._iterator = this._db.prepare(sql).iterate();
   }
 
   _read() {
     const elt = this._iterator.next();
-    if(!this.push(!elt.done && elt.value ? elt.value.body : null)) {
+    if(!this.push(!elt.done && elt.value ? elt.value : null)) {
       this._db.close();
     }
   }

--- a/src/components/sqliteStream.js
+++ b/src/components/sqliteStream.js
@@ -5,6 +5,14 @@ const logger = require('pelias-logger').get('whosonfirst:sqliteStream');
 class SQLiteStream extends Readable {
   constructor(dbPath, sql) {
     super({ objectMode: true, autoDestroy: true, highWaterMark: 32 });
+
+    // ensure indices exist
+    // note: this can be removed once the upstream PR is merged:
+    // https://github.com/whosonfirst/go-whosonfirst-sqlite-features/pull/4
+    new Sqlite3(dbPath)
+      .exec('CREATE INDEX IF NOT EXISTS spr_obsolete ON spr (is_deprecated, is_superseded)')
+      .close();
+
     this._db = new Sqlite3(dbPath, { readonly: true });
     this._iterator = this._db.prepare(sql).iterate();
     this.on('error', (e) => { logger.error(e); });
@@ -29,16 +37,14 @@ function findGeoJSON() {
 SELECT geojson.id, geojson.body
   FROM geojson JOIN spr
   ON geojson.id = spr.id
-  WHERE
-    geojson.id != 1
-      AND
-    spr.is_deprecated = 0
-      AND
-    spr.is_superseded = 0
-      AND
-    spr.name <> ''
-      AND
-    (spr.latitude != 0 OR spr.longitude != 0)`;
+  WHERE geojson.id != 1
+  AND spr.is_deprecated = 0
+  AND spr.is_superseded = 0
+  AND NOT TRIM( IFNULL(spr.name, '') ) = ''
+  AND NOT (
+    spr.latitude = 0 AND
+    spr.longitude = 0
+  )`;
 }
 
 /**

--- a/src/components/sqliteStream.js
+++ b/src/components/sqliteStream.js
@@ -32,6 +32,8 @@ SELECT geojson.id, geojson.body
       AND
     spr.is_superseded = 0
       AND
+    spr.name <> ''
+      AND
     (spr.latitude != 0 OR spr.longitude != 0)`;
 }
 
@@ -39,6 +41,7 @@ SELECT geojson.id, geojson.body
  * Add filter and placetypes
  */
 function findGeoJSONByPlacetype(placetypes) {
+  placetypes = typeof placetypes === 'string' ? [placetypes] : placetypes;
   return findGeoJSON() + `
       AND
     spr.placetype IN ('${placetypes.join('\',\'')}')

--- a/src/components/sqliteStream.js
+++ b/src/components/sqliteStream.js
@@ -46,10 +46,29 @@ function findGeoJSONByPlacetype(placetypes) {
   }
   return findGeoJSON() + `
       AND
-    spr.placetype IN ('${placetypes.join('\',\'')}')
-`;
+    spr.placetype IN ('${placetypes.join('\',\'')}')`;
+}
+function findGeoJSONByPlacetypeAndWOFId(placetypes, wofids) {
+  if(!Array.isArray(wofids)) {
+    wofids = [ wofids ];
+  }
+  wofids = wofids.map(id => parseInt(id, 10)).join(',');
+  return findGeoJSONByPlacetype(placetypes) + `
+      AND
+    spr.id IN (
+      SELECT DISTINCT id
+        FROM ancestors
+        WHERE id IN (${wofids})
+      UNION SELECT DISTINCT id
+        FROM ancestors
+        WHERE ancestor_id IN (${wofids})
+      UNION SELECT DISTINCT ancestor_id
+        FROM ancestors
+        WHERE id IN (${wofids})
+    )`;
 }
 
 module.exports = SQLiteStream;
 module.exports.findGeoJSON = findGeoJSON;
 module.exports.findGeoJSONByPlacetype = findGeoJSONByPlacetype;
+module.exports.findGeoJSONByPlacetypeAndWOFId = findGeoJSONByPlacetypeAndWOFId;

--- a/src/components/toJSONStream.js
+++ b/src/components/toJSONStream.js
@@ -8,8 +8,9 @@ module.exports.create = () => {
     try {
       next(null, JSON.parse(record.body));
     } catch (parse_err) {
-      logger.error(`exception parsing JSON for id ${record.id}: ${parse_err}`);
-      next(parse_err);
+      // By-pass this malformed entry
+      logger.warn(`exception parsing JSON for id ${record.id}: ${parse_err}`);
+      next();
     }
   });
 };

--- a/src/components/toJSONStream.js
+++ b/src/components/toJSONStream.js
@@ -1,0 +1,15 @@
+const parallelTransform = require('parallel-transform');
+const logger = require( 'pelias-logger' ).get( 'whosonfirst' );
+
+const maxInFlight = 10;
+
+module.exports.create = () => {
+  return parallelTransform(maxInFlight, function(record, next) {
+    try {
+      next(null, JSON.parse(record.body));
+    } catch (parse_err) {
+      logger.error(`exception parsing JSON for id ${record.id}: ${parse_err}`);
+      next(parse_err);
+    }
+  });
+};

--- a/src/components/toJSONStream.js
+++ b/src/components/toJSONStream.js
@@ -1,10 +1,8 @@
-const parallelTransform = require('parallel-transform');
+const through2 = require('through2');
 const logger = require( 'pelias-logger' ).get( 'whosonfirst' );
 
-const maxInFlight = 10;
-
 module.exports.create = () => {
-  return parallelTransform(maxInFlight, function(record, next) {
+  return through2.obj((record, enc, next) => {
     try {
       next(null, JSON.parse(record.body));
     } catch (parse_err) {

--- a/src/readStream.js
+++ b/src/readStream.js
@@ -26,7 +26,7 @@ function getMetaFilePaths(wofRoot, bundles) {
 }
 
 /*
- * Convert a base directory and list of types into a list of sqlite file paths
+ * Convert a base directory and list of databases names into a list of sqlite file paths
  */
 function getSqliteFilePaths(wofRoot, databases) {
   return databases.map((database) => {
@@ -93,7 +93,7 @@ function createReadStream(wofConfig, types, wofAdminRecords) {
   const metaFilePaths = getMetaFilePaths(wofRoot, types);
 
   // Select correct stream between meta and SQLite based on config and do specialized stuff
-  const stream = wofConfig.sqlite ?
+  const stream = wofConfig.sqlite === true ?
     createSQLiteRecordStream(getSqliteFilePaths(wofRoot, types))
       .pipe(toJSONStream.create()) :
     createMetaRecordStream(metaFilePaths, types)

--- a/src/readStream.js
+++ b/src/readStream.js
@@ -78,7 +78,7 @@ function createSQLiteRecordStream(dbPaths, importPlace) {
 
   dbPaths.forEach((dbPath) => {
     sqliteStream.append( (next) => {
-      logger.info( `Loading ${path.basename(dbPath)} records from ${path.dirname(dbPath)}` );
+      logger.info( `Loading ${path.basename(dbPath)} database from ${path.dirname(dbPath)}` );
       next(new SQLiteStream(dbPath, sqliteStatement));
     });
   });

--- a/test/bundleList.js
+++ b/test/bundleList.js
@@ -2,7 +2,9 @@ const tape = require('tape');
 const proxyquire = require('proxyquire');
 const fs = require('fs-extra');
 const _ = require('lodash');
+const path = require('path');
 const peliasConfig = require('pelias-config');
+const temp = require('temp').track();
 
 proxyquire.noPreserveCache();
 proxyquire.noCallThru();
@@ -31,6 +33,12 @@ const POSTALCODES = [
 
 const VENUES = [
   'venue'
+];
+
+const SQLITE_EXAMPLE = [
+  'whosonfirst-data-latest.db',
+  'whosonfirst-data-postalcode-fr-latest.db',
+  'whosonfirst-data-postalcode-jp-latest.db'
 ];
 
 tape('bundlesList tests', (test) => {
@@ -177,6 +185,64 @@ tape('bundlesList tests', (test) => {
       t.end();
 
       process.argv[2] = previousValue;
+    });
+  });
+
+  test.test('supports sqlite', (t) => {
+    temp.mkdir('supports_sqlite', (err, temp_dir) => {
+      const config = {
+        generate: () => {
+          return peliasConfig.generateCustom({
+            imports: {
+              whosonfirst: {
+                datapath: temp_dir,
+                sqlite: true
+              }
+            }
+          });
+        }
+      };
+      SQLITE_EXAMPLE
+        .concat(['ignore_me.csv', 'README.md'])
+        .forEach(e => fs.createFileSync(path.join(temp_dir, 'sqlite', e), ''));
+
+      const bundles = proxyquire('../src/bundleList', { 'pelias-config': config });
+
+      bundles.generateBundleList((e, bundlesList) => {
+        temp.cleanup((err) => {
+          t.notOk(err);
+          t.notOk(e);
+          t.deepEqual(bundlesList, SQLITE_EXAMPLE);
+          t.end();
+        });
+      });
+    });
+
+    test.test('Error when no sqlite is present', (t) => {
+      temp.mkdir('missing_sqlite', (err, temp_dir) => {
+        const config = {
+          generate: () => {
+            return peliasConfig.generateCustom({
+              imports: {
+                whosonfirst: {
+                  datapath: temp_dir,
+                  sqlite: true
+                }
+              }
+            });
+          }
+        };
+        const bundles = proxyquire('../src/bundleList', { 'pelias-config': config });
+
+        bundles.generateBundleList((e, bundlesList) => {
+          temp.cleanup((err) => {
+            t.notOk(err);
+            t.ok(e);
+            t.deepEqual(bundlesList, undefined);
+            t.end();
+          });
+        });
+      });
     });
   });
   test.end();

--- a/test/bundleList.js
+++ b/test/bundleList.js
@@ -36,6 +36,7 @@ const VENUES = [
 ];
 
 const SQLITE_EXAMPLE = [
+  'whosonfirst-data-constituency-us-ct-1481486175.db',
   'whosonfirst-data-latest.db',
   'whosonfirst-data-postalcode-fr-latest.db',
   'whosonfirst-data-postalcode-jp-latest.db'

--- a/test/components/sqliteStream.js
+++ b/test/components/sqliteStream.js
@@ -12,7 +12,8 @@ tape('SQLiteStream', (test) => {
     temp.mkdir('tmp_SQLite_db', (err, temp_dir) => {
       const dbPath = path.join(temp_dir, 'stream_test.db');
       const tmpDB = new Sqlite3(dbPath)
-        .exec('CREATE TABLE wof(id INT)')
+        .exec('CREATE TABLE wof(id INTEGER)')
+        .exec('CREATE TABLE spr(id INTEGER, is_deprecated INTEGER, is_superseded INTEGER)')
         .exec('INSERT INTO wof(id) VALUES (0), (1), (2)');
       const sqliteStream = new SQLiteStream(dbPath, 'SELECT * FROM wof');
       const res = [];
@@ -38,7 +39,8 @@ tape('SQLiteStream', (test) => {
         const delta = idx === 0 ? 0 : 3;
         const dbPath = path.join(temp_dir, e);
         const tmpDB = new Sqlite3(dbPath)
-          .exec('CREATE TABLE wof(id INT)')
+          .exec('CREATE TABLE wof(id INTEGER)')
+          .exec('CREATE TABLE spr(id INTEGER, is_deprecated INTEGER, is_superseded INTEGER)')
           .exec(`INSERT INTO wof(id) VALUES (${delta + 0}), (${delta + 1}), (${delta + 2})`);
         stream.append(next => {
           next(new SQLiteStream(dbPath, 'SELECT * FROM wof'));

--- a/test/components/sqliteStream.js
+++ b/test/components/sqliteStream.js
@@ -1,0 +1,61 @@
+const combinedStream = require('combined-stream');
+const fs = require('fs');
+const path = require('path');
+const Sqlite3 = require('better-sqlite3');
+const SQLiteStream = require('../../src/components/sqliteStream');
+const tape = require('tape');
+const temp = require('temp').track();
+const through2 = require('through2');
+
+tape('SQLiteStream', (test) => {
+  test.test('Should be a read stream', (t) => {
+    temp.mkdir('tmp_SQLite_db', (err, temp_dir) => {
+      const dbPath = path.join(temp_dir, 'stream_test.db');
+      const tmpDB = new Sqlite3(dbPath)
+        .exec('CREATE TABLE wof(id INT)')
+        .exec('INSERT INTO wof(id) VALUES (0), (1), (2)');
+      const sqliteStream = new SQLiteStream(dbPath, 'SELECT * FROM wof');
+      const res = [];
+      sqliteStream.pipe(through2.obj((data, enc, next) => {
+        res.push(data.id);
+        next();
+      })).on('finish', () => {
+        temp.cleanup((err) => {
+          tmpDB.close();
+          t.notOk(err);
+          t.deepEqual([0, 1, 2], res);
+          t.notOk(sqliteStream._db.open, 'database should be closed at the end');
+          t.end();
+        });
+      });
+    });
+  });
+  test.test('Should be used with combinedStream', (t) => {
+    temp.mkdir('tmp_SQLite_combinedStream', (err, temp_dir) => {
+      const stream = combinedStream.create();
+      const streams = ['combinedStream1.db', 'combinedStream2.db'].map((e, idx) => {
+        const delta = idx === 0 ? 0 : 3;
+        const dbPath = path.join(temp_dir, e);
+        const tmpDB = new Sqlite3(dbPath)
+          .exec('CREATE TABLE wof(id INT)')
+          .exec(`INSERT INTO wof(id) VALUES (${delta + 0}), (${delta + 1}), (${delta + 2})`);
+        stream.append(next => {
+          next(new SQLiteStream(dbPath, 'SELECT * FROM wof'));
+        });
+        return tmpDB;
+      });
+      const res = [];
+      stream.pipe(through2.obj((data, enc, next) => {
+        res.push(data.id);
+        next();
+      })).on('finish', () => {
+        temp.cleanup((err) => {
+          streams.forEach(s => s.close());
+          t.notOk(err);
+          t.deepEqual(res, [0, 1, 2, 3, 4, 5]);
+          t.end();
+        });
+      });
+    });
+  });
+});

--- a/test/components/sqliteStream.js
+++ b/test/components/sqliteStream.js
@@ -30,6 +30,7 @@ tape('SQLiteStream', (test) => {
       });
     });
   });
+
   test.test('Should be used with combinedStream', (t) => {
     temp.mkdir('tmp_SQLite_combinedStream', (err, temp_dir) => {
       const stream = combinedStream.create();
@@ -57,5 +58,17 @@ tape('SQLiteStream', (test) => {
         });
       });
     });
+  });
+
+  test.test('Should generate correct sqlite statement when findGeoJSONByPlacetype is used', t => {
+    t.ok(SQLiteStream.findGeoJSONByPlacetype(undefined).indexOf(`spr.placetype IN ('')`) >= 0,
+        'Should change undefined value to empty string');
+    t.ok(SQLiteStream.findGeoJSONByPlacetype(42).indexOf(`spr.placetype IN ('42')`) >= 0,
+        'Should change number to string');
+    t.ok(SQLiteStream.findGeoJSONByPlacetype('placetype').indexOf(`spr.placetype IN ('placetype')`) >= 0,
+        'Should format correctly strings');
+    t.ok(SQLiteStream.findGeoJSONByPlacetype(['locality', 'localadmin']).indexOf(`spr.placetype IN ('locality','localadmin')`) >= 0,
+        'Should format correctly array of strings');
+    t.end();
   });
 });

--- a/test/generateWOFDB.js
+++ b/test/generateWOFDB.js
@@ -37,8 +37,9 @@ module.exports = (dbPath, entries) => {
     entries.forEach(e => {
       db
       .exec(`INSERT INTO geojson(id, body) VALUES (${e.id}, '${JSON.stringify(e)}')`)
-      .exec(`INSERT INTO spr(id, placetype, latitude, longitude, is_deprecated, is_superseded) VALUES (
+      .exec(`INSERT INTO spr(id, name, placetype, latitude, longitude, is_deprecated, is_superseded) VALUES (
         ${e.id},
+        '${e.properties['wof:name'] || ''}',
         '${e['wof:placetype']}',
         ${e.properties['geom:latitude']},
         ${e.properties['geom:longitude']},

--- a/test/generateWOFDB.js
+++ b/test/generateWOFDB.js
@@ -6,46 +6,52 @@ const Sqlite3 = require('better-sqlite3');
 module.exports = (dbPath, entries) => {
   fs.ensureDirSync(path.dirname(dbPath));
   const db = new Sqlite3(dbPath)
-    .exec(`CREATE TABLE geojson (
-        		id INTEGER NOT NULL PRIMARY KEY,
-        		body TEXT,
-        		lastmodified INTEGER
+    .exec(`
+          CREATE TABLE geojson (
+            id INTEGER NOT NULL PRIMARY KEY,
+            body TEXT,
+            lastmodified INTEGER
           )`)
-    .exec(`CREATE TABLE spr (
-          	id INTEGER NOT NULL PRIMARY KEY,
-          	parent_id INTEGER,
-          	name TEXT,
-          	placetype TEXT,
-          	country TEXT,
-          	repo TEXT,
-          	latitude REAL,
-          	longitude REAL,
-          	min_latitude REAL,
-          	min_longitude REAL,
-          	max_latitude REAL,
-          	max_longitude REAL,
-          	is_current INTEGER,
-          	is_deprecated INTEGER,
-          	is_ceased INTEGER,
-          	is_superseded INTEGER,
-          	is_superseding INTEGER,
-          	superseded_by TEXT,
-          	supersedes TEXT,
-          	lastmodified INTEGER
+    .exec(`
+          CREATE TABLE spr (
+            id INTEGER NOT NULL PRIMARY KEY,
+            parent_id INTEGER,
+            name TEXT,
+            placetype TEXT,
+            country TEXT,
+            repo TEXT,
+            latitude REAL,
+            longitude REAL,
+            min_latitude REAL,
+            min_longitude REAL,
+            max_latitude REAL,
+            max_longitude REAL,
+            is_current INTEGER,
+            is_deprecated INTEGER,
+            is_ceased INTEGER,
+            is_superseded INTEGER,
+            is_superseding INTEGER,
+            superseded_by TEXT,
+            supersedes TEXT,
+            lastmodified INTEGER
           )`);
   if (_.isArray(entries)) {
     entries.forEach(e => {
       db
       .exec(`INSERT INTO geojson(id, body) VALUES (${e.id}, '${JSON.stringify(e)}')`)
-      .exec(`INSERT INTO spr(id, name, placetype, latitude, longitude, is_deprecated, is_superseded) VALUES (
-        ${e.id},
-        '${e.properties['wof:name'] || ''}',
-        '${e['wof:placetype']}',
-        ${e.properties['geom:latitude']},
-        ${e.properties['geom:longitude']},
-        ${_.isEmpty(e.properties['edtf:deprecated']) ? 0 : 1},
-        ${_.isEmpty(e.properties['wof:superseded_by']) ? 0 : 1}
-      )`);
+      .exec(`
+        INSERT INTO spr(
+          id, name, placetype, latitude, longitude,
+          is_deprecated, is_superseded
+        ) VALUES (
+          ${e.id},
+          '${e.properties['wof:name'] || ''}',
+          '${e['wof:placetype']}',
+          ${e.properties['geom:latitude']},
+          ${e.properties['geom:longitude']},
+          ${_.isEmpty(e.properties['edtf:deprecated']) ? 0 : 1},
+          ${_.isEmpty(e.properties['wof:superseded_by']) ? 0 : 1}
+        )`);
     });
   }
   return db;

--- a/test/generateWOFDB.js
+++ b/test/generateWOFDB.js
@@ -1,0 +1,51 @@
+const _ = require('lodash');
+const path = require('path');
+const fs = require('fs-extra');
+const Sqlite3 = require('better-sqlite3');
+
+module.exports = (dbPath, entries) => {
+  fs.ensureDirSync(path.dirname(dbPath));
+  const db = new Sqlite3(dbPath)
+    .exec(`CREATE TABLE geojson (
+        		id INTEGER NOT NULL PRIMARY KEY,
+        		body TEXT,
+        		lastmodified INTEGER
+          )`)
+    .exec(`CREATE TABLE spr (
+          	id INTEGER NOT NULL PRIMARY KEY,
+          	parent_id INTEGER,
+          	name TEXT,
+          	placetype TEXT,
+          	country TEXT,
+          	repo TEXT,
+          	latitude REAL,
+          	longitude REAL,
+          	min_latitude REAL,
+          	min_longitude REAL,
+          	max_latitude REAL,
+          	max_longitude REAL,
+          	is_current INTEGER,
+          	is_deprecated INTEGER,
+          	is_ceased INTEGER,
+          	is_superseded INTEGER,
+          	is_superseding INTEGER,
+          	superseded_by TEXT,
+          	supersedes TEXT,
+          	lastmodified INTEGER
+          )`);
+  if (_.isArray(entries)) {
+    entries.forEach(e => {
+      db
+      .exec(`INSERT INTO geojson(id, body) VALUES (${e.id}, '${JSON.stringify(e)}')`)
+      .exec(`INSERT INTO spr(id, placetype, latitude, longitude, is_deprecated, is_superseded) VALUES (
+        ${e.id},
+        '${e['wof:placetype']}',
+        ${e.properties['geom:latitude']},
+        ${e.properties['geom:longitude']},
+        ${_.isEmpty(e.properties['edtf:deprecated']) ? 0 : 1},
+        ${_.isEmpty(e.properties['wof:superseded_by']) ? 0 : 1}
+      )`);
+    });
+  }
+  return db;
+};

--- a/test/readStreamTest.js
+++ b/test/readStreamTest.js
@@ -180,7 +180,7 @@ tape('readStream', (test) => {
 
   test.test('load sqlite', t => {
     temp.mkdir('tmp_sqlite', (err, temp_dir) => {
-      const db = generateWOFDB(path.join(temp_dir, 'sqlite', 'whosonfirst-data-latest.db'), [
+      generateWOFDB(path.join(temp_dir, 'sqlite', 'whosonfirst-data-latest.db'), [
         {
           id: 0,
           'wof:placetype': 'country',

--- a/test/readStreamTest.js
+++ b/test/readStreamTest.js
@@ -211,6 +211,15 @@ tape('readStream', (test) => {
             'geom:longitude': 3.916216,
             'wof:superseded_by': ['421302191']
           }
+        },
+        {
+          id: 421302897,
+          'wof:placetype': 'locality',
+          properties: {
+            'geom:latitude': 4.2564,
+            'geom:longitude': -41.916216,
+            'wof:superseded_by': []
+          }
         }
       ]);
       const records = {};

--- a/test/test.js
+++ b/test/test.js
@@ -7,6 +7,7 @@ require ('./components/metadataStream.js');
 require ('./components/parseMetaFiles.js');
 require ('./components/recordHasIdAndPropertiesTest.js');
 require ('./components/recordHasNameTest.js');
+require ('./components/sqliteStream.js');
 require ('./components/wofIdToPath.js');
 require ('./hierarchyFinderTest.js');
 require ('./importStreamTest.js');

--- a/utils/download_data.js
+++ b/utils/download_data.js
@@ -62,5 +62,9 @@ if( config.importPlace ) {
   });
 }
 else {
-  require('./download_data_all').download(on_done);
+  if ( config.sqlite ) {
+    require('./download_sqlite_all').download(on_done);
+  } else {
+    require('./download_data_all').download(on_done);
+  }
 }

--- a/utils/download_data_all.js
+++ b/utils/download_data_all.js
@@ -32,7 +32,7 @@ function download(callback) {
     const csvFilename = bundle.replace(/-\d{8}T\d{6}-/, '-latest-') // support timestamped downloads
                               .replace('.tar.bz2', '.csv');
 
-    return `curl ${wofDataHost}/bundles/${bundle} | tar -xj --strip-components=1 --exclude=README.txt -C ` +
+    return `curl -s ${wofDataHost}/bundles/${bundle} | tar -xj --strip-components=1 --exclude=README.txt -C ` +
       `${directory} && mv ${path.join(directory, csvFilename)} ${path.join(directory, 'meta')}`;
   }
 

--- a/utils/download_sqlite_all.js
+++ b/utils/download_sqlite_all.js
@@ -1,0 +1,81 @@
+const child_process = require('child_process');
+const async = require('async');
+const fs = require('fs-extra');
+const os = require('os');
+const path = require('path');
+const downloadFileSync = require('download-file-sync');
+
+const config = require('pelias-config').generate(require('../schema'));
+
+const wofDataHost = config.get('imports.whosonfirst.dataHost') || 'https://dist.whosonfirst.org';
+
+function download(callback) {
+  //ensure required directory structure exists
+  fs.ensureDirSync(path.join(config.imports.whosonfirst.datapath, 'sqlite'));
+
+  // download one bundle for every other CPU (tar and bzip2 can both max out one core)
+  // (the maximum is configurable, to keep things from getting too intense, and defaults to 4)
+  //lower this number to make the downloader more CPU friendly
+  //raise this number to (possibly) make it faster
+  const maxSimultaneousDownloads = config.get('imports.whosonfirst.maxDownloads') || 4;
+  const cpuCount = os.cpus().length;
+  const simultaneousDownloads = Math.max(maxSimultaneousDownloads, Math.min(1, cpuCount / 2));
+
+  const generateSQLites = () => {
+    const files = {};
+    const content = JSON.parse(downloadFileSync(`${wofDataHost}/sqlite/inventory.json`))
+       // Only latest compressed files
+      .filter(e => e.name_compressed.indexOf('latest') >= 0)
+      // Postalcodes only when importPostalcodes is ture and without --admin-only arg
+      .filter(e => e.name_compressed.indexOf('postalcode') < 0 || 
+        (config.imports.whosonfirst.importPostalcodes && process.argv[2] !== '--admin-only'))
+      // Venues only when importVenues is true and without --admin-only arg
+      .filter(e => e.name_compressed.indexOf('venue') < 0 ||
+        (config.imports.whosonfirst.importVenues && process.argv[2] !== '--admin-only'))
+      // We don't need constituency and intersection ?
+      .filter(e => e.name_compressed.indexOf('constituency') < 0 && e.name_compressed.indexOf('intersection') < 0)
+      // Remove duplicates based on name, we can have differents name_compressed
+      // (for example whosonfirst-data-latest.db.bz2 and whosonfirst-data-latest.db.tar.bz2)
+      // but with the same name... We will take the newer version.
+      .forEach(e => {
+        if (files[e.name] && new Date(e.last_modified) > new Date(files[e.name].last_modified)) {
+          files[e.name] = e;
+        } else if (!files[e.name]) {
+          files[e.name] = e;
+        }
+      });
+    return Object.values(files);
+  };
+
+  const generateCommand = (sqlite, directory) => {
+    let extract;
+    if (/\.db\.bz2$/.test(sqlite.name_compressed)) {
+      extract = `bunzip2`;
+    } else if(/\.db\.tar\.bz2$/.test(sqlite.name_compressed)) {
+      extract = `tar -xjO`;
+    } else { 
+      throw new Error('What is this extension ?!?');
+    }
+
+    return `curl ${wofDataHost}/sqlite/${sqlite.name_compressed} | ${extract} > ${path.join(directory, 'sqlite', sqlite.name)}`;
+  };
+
+  const downloadFunctions = generateSQLites().map(function (sqlite) {
+    return function downloadABundle(callback) {
+      const cmd = generateCommand(sqlite, config.imports.whosonfirst.datapath);
+      console.log('Downloading ' + sqlite.name_compressed);
+      child_process.exec(cmd, function commandCallback(error, stdout, stderr) {
+        console.log('done downloading ' + sqlite.name_compressed);
+        if (error) {
+          console.error('error downloading ' + sqlite.name_compressed + error);
+          console.log(stderr);
+        }
+        callback();
+      });
+    };
+  });
+
+  async.parallelLimit(downloadFunctions, simultaneousDownloads, callback);
+}
+
+module.exports.download = download;

--- a/utils/download_sqlite_all.js
+++ b/utils/download_sqlite_all.js
@@ -27,7 +27,7 @@ function download(callback) {
        // Only latest compressed files
       .filter(e => e.name_compressed.indexOf('latest') >= 0)
       // Postalcodes only when importPostalcodes is ture and without --admin-only arg
-      .filter(e => e.name_compressed.indexOf('postalcode') < 0 || 
+      .filter(e => e.name_compressed.indexOf('postalcode') < 0 ||
         (config.imports.whosonfirst.importPostalcodes && process.argv[2] !== '--admin-only'))
       // Venues only when importVenues is true and without --admin-only arg
       .filter(e => e.name_compressed.indexOf('venue') < 0 ||
@@ -53,11 +53,11 @@ function download(callback) {
       extract = `bunzip2`;
     } else if(/\.db\.tar\.bz2$/.test(sqlite.name_compressed)) {
       extract = `tar -xjO`;
-    } else { 
+    } else {
       throw new Error('What is this extension ?!?');
     }
 
-    return `curl ${wofDataHost}/sqlite/${sqlite.name_compressed} | ${extract} > ${path.join(directory, 'sqlite', sqlite.name)}`;
+    return `curl -s ${wofDataHost}/sqlite/${sqlite.name_compressed} | ${extract} > ${path.join(directory, 'sqlite', sqlite.name)}`;
   };
 
   const downloadFunctions = generateSQLites().map(function (sqlite) {

--- a/utils/sqlite_clean.js
+++ b/utils/sqlite_clean.js
@@ -1,0 +1,31 @@
+const Sqlite3 = require('better-sqlite3');
+const path = require('path');
+const generateBundleList = require('../src/bundleList').generateBundleList;
+const config = require('pelias-config').generate(require('../schema')).imports.whosonfirst;
+
+if (config.sqlite) {
+  const filters = ` id = 1 OR name = ''
+    OR is_deprecated != 0 OR is_superseded != 0
+    OR (spr.latitude != 0 AND spr.longitude != 0)` +
+    (config.importPostalcodes ? '' : ` OR placetype = 'postalcode' `) +
+    (config.importVenues ? '' : ` OR placetype = 'venue' `) +
+    (config.importConstituencies ? '' : ` OR placetype = 'constituency' `) +
+    (config.importIntersections ? '' : ` OR placetype = 'intersection' `);
+  generateBundleList((e, dbList) => {
+    if (e) {
+      console.error(e);
+      return;
+    }
+    dbList.forEach(datapath => {
+      const sqlite = new Sqlite3(path.join(config.datapath, 'sqlite', datapath));
+      sqlite
+        .exec('DROP TABLE IF EXISTS names;')
+        .exec('DROP TABLE IF EXISTS concordances;')
+        .exec(`DELETE FROM geojson WHERE id IN(SELECT id FROM spr WHERE ${filters});`)
+        .exec(`DELETE FROM spr WHERE ${filters};`)
+        .exec('vacuum;');
+    });
+  });
+} else {
+  console.log('nothing to do');
+}


### PR DESCRIPTION
This PR add supports to SQLite databases.
[pelias/whosonfirst](https://github.com/pelias/whosonfirst) will still supports bundle, for sqlite import, a new options will be added : `imports.whosonfirst.sqlite` (false by default for backward compatibility).

TODO list:
- [x] SQLite read stream
- [x] List available databases
- [x] Add `imports.whosonfirst.sqlite` configuration
- [x] Add SQLite stream in import pipeline
- [x] Download SQLite database for world `utils/download_data_all.js`
- [x] Check performances between SQLite and bundle
- [x] Expose SQLite Read Stream (for [pelias/wof-admin-lookup](https://github.com/pelias/wof-admin-lookup))
- [x] Cleanup SQLite (this can take some times)
- [x] Supports importPlace


fixes #416 