### PR TITLE
feat(logger): Use dbclient name functionality

### DIFF
--- a/import.js
+++ b/import.js
@@ -1,4 +1,3 @@
-
 var peliasConfig = require( 'pelias-config' ).generate(require('./schema'));
 var readStreamModule = require('./src/readStream');
 var importStream = require('./src/importStream');
@@ -34,7 +33,7 @@ bundles.generateBundleList((err, bundlesToImport) => {
   var documentGenerator = peliasDocGenerators.create(hierarchyFinder(wofAdminRecords));
 
   // the final destination of Pelias Documents
-  var dbClientStream = peliasDbclient();
+  var dbClientStream = peliasDbclient({name: 'whosonfirst'});
 
   // import WOF records into ES
   importStream(readStream, documentGenerator, dbClientStream, function () {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "parallel-transform": "^1.1.0",
     "pelias-blacklist-stream": "^1.0.0",
     "pelias-config": "^3.8.1",
-    "pelias-dbclient": "^2.5.6",
+    "pelias-dbclient": "^2.8.0",
     "pelias-logger": "^1.2.1",
     "pelias-model": "^5.5.2",
     "through2": "^3.0.0",


### PR DESCRIPTION
This allows distinguishing which logger output lines correspond to which
importer during an import.

Connects https://github.com/pelias/dbclient/issues/101