### PR TITLE
index aliases for name.default

### DIFF
--- a/src/components/extractFields.js
+++ b/src/components/extractFields.js
@@ -16,6 +16,12 @@ const population_hierarchy = [
   'ne:pop_est'
 ];
 
+// WOF fields to use for aliases
+const name_alias_fields = [
+  'name:eng_x_preferred',
+  'name:eng_x_variant'
+];
+
 // this function is used to verify that a US county QS altname is available
 function isUsCounty(base_record, wof_country, qs_a2_alt) {
   return 'US' === wof_country &&
@@ -65,6 +71,17 @@ function getName(properties) {
   }
 }
 
+function getNameAliases(properties) {
+  let aliases = [];
+  name_alias_fields.forEach(field => {
+    if( Array.isArray(properties[field]) && properties[field].length ){
+      aliases = aliases.concat(properties[field]);
+    }
+  });
+  // dedupe array
+  return aliases.filter((item, pos, self) => self.indexOf(item) === pos);
+}
+
 function getAbbreviation(properties) {
   if (properties['wof:placetype'] === 'country' && properties['wof:country']) {
     return properties['wof:country'];
@@ -104,6 +121,7 @@ module.exports.create = function map_fields_stream() {
     var record = {
       id: json_object.id,
       name: getName(json_object.properties),
+      name_aliases: getNameAliases(json_object.properties),
       abbreviation: getAbbreviation(json_object.properties),
       place_type: json_object.properties['wof:placetype'],
       lat: getLat(json_object.properties),

--- a/src/peliasDocGenerators.js
+++ b/src/peliasDocGenerators.js
@@ -70,6 +70,13 @@ function setupDocument(record, hierarchy) {
         wofDoc.setNameAlias('default', sans_whitespace);
       }
     }
+
+    // index name aliases for all other records (where available)
+    else if (record.name_aliases.length) {
+      record.name_aliases.forEach(alias => {
+        wofDoc.setNameAlias('default', alias);
+      });
+    }
   }
   wofDoc.setCentroid({ lat: record.lat, lon: record.lon });
 

--- a/test/components/extractFieldsTest.js
+++ b/test/components/extractFieldsTest.js
@@ -53,6 +53,7 @@ tape('readStreamComponents', function(test) {
       {
         id: 12345,
         name: 'name 1',
+        name_aliases: [],
         place_type: 'place type 1',
         lat: 12.121212,
         lon: 21.212121,
@@ -90,6 +91,7 @@ tape('readStreamComponents', function(test) {
       {
         id: 23456,
         name: undefined,
+        name_aliases: [],
         place_type: undefined,
         lat: undefined,
         lon: undefined,
@@ -127,6 +129,7 @@ tape('readStreamComponents', function(test) {
       {
         id: 12345,
         name: 'name 1',
+        name_aliases: [],
         place_type: 'place type 1',
         lat: 12.121212,
         lon: 21.212121,
@@ -167,6 +170,7 @@ tape('readStreamComponents', function(test) {
       {
         id: 12345,
         name: 'name 1',
+        name_aliases: [],
         place_type: 'place type 1',
         lat: 12.121212,
         lon: 21.212121,
@@ -208,6 +212,7 @@ tape('readStreamComponents', function(test) {
       {
         id: 12345,
         name: 'name 1',
+        name_aliases: [],
         place_type: 'place type 1',
         lat: 12.121212,
         lon: 21.212121,
@@ -250,6 +255,7 @@ tape('readStreamComponents', function(test) {
       {
         id: 12345,
         name: 'qs:a2_alt value',
+        name_aliases: [],
         place_type: 'county',
         lat: 12.121212,
         lon: 21.212121,
@@ -290,6 +296,7 @@ tape('readStreamComponents', function(test) {
       {
         id: 12345,
         name: 'wof:name value',
+        name_aliases: [],
         place_type: 'county',
         lat: 12.121212,
         lon: 21.212121,
@@ -331,6 +338,7 @@ tape('readStreamComponents', function(test) {
       {
         id: 12345,
         name: 'wof:name value',
+        name_aliases: [],
         place_type: 'county',
         lat: 12.121212,
         lon: 21.212121,
@@ -371,6 +379,7 @@ tape('readStreamComponents', function(test) {
       {
         id: 12345,
         name: 'wof:name value',
+        name_aliases: [],
         place_type: undefined,
         lat: 14.141414,
         lon: 23.232323,
@@ -406,6 +415,7 @@ tape('readStreamComponents', function(test) {
       {
         id: 12345,
         name: 'wof:name value',
+        name_aliases: [],
         place_type: undefined,
         lat: 12.121212,
         lon: 21.212121,
@@ -441,6 +451,7 @@ tape('readStreamComponents', function(test) {
       {
         id: 12345,
         name: 'wof:name value',
+        name_aliases: [],
         place_type: undefined,
         lat: 12.121212,
         lon: 21.212121,
@@ -476,6 +487,7 @@ tape('readStreamComponents', function(test) {
       {
         id: 12345,
         name: 'wof:label value',
+        name_aliases: [],
         place_type: undefined,
         lat: 12.121212,
         lon: 21.212121,
@@ -511,6 +523,7 @@ tape('readStreamComponents', function(test) {
       {
         id: 12345,
         name: 'wof:name value',
+        name_aliases: [],
         place_type: 'locality',
         lat: undefined,
         lon: undefined,
@@ -548,6 +561,7 @@ tape('readStreamComponents', function(test) {
       {
         id: 12345,
         name: 'wof:name value',
+        name_aliases: [],
         place_type: 'locality',
         lat: undefined,
         lon: undefined,
@@ -586,6 +600,7 @@ tape('readStreamComponents', function(test) {
       {
         id: 12345,
         name: 'wof:name value',
+        name_aliases: [],
         place_type: 'country',
         lat: undefined,
         lon: undefined,
@@ -626,6 +641,7 @@ tape('readStreamComponents', function(test) {
       {
         id: 12345,
         name: 'wof:name value',
+        name_aliases: [],
         place_type: 'dependency',
         lat: undefined,
         lon: undefined,
@@ -664,6 +680,7 @@ tape('readStreamComponents', function(test) {
       {
         id: 12345,
         name: 'wof:name value',
+        name_aliases: [],
         place_type: 'dependency',
         lat: undefined,
         lon: undefined,
@@ -701,6 +718,7 @@ tape('readStreamComponents', function(test) {
       {
         id: 12345,
         name: 'wof:name value',
+        name_aliases: [],
         place_type: 'dependency',
         lat: undefined,
         lon: undefined,
@@ -740,6 +758,7 @@ tape('readStreamComponents', function(test) {
       {
         id: 12345,
         name: 'wof:name value',
+        name_aliases: [],
         place_type: 'country',
         lat: undefined,
         lon: undefined,
@@ -792,6 +811,7 @@ tape('population fallback tests', (test) => {
       {
         id: 12345,
         name: 'wof:name value',
+        name_aliases: [],
         place_type: 'country',
         lat: undefined,
         lon: undefined,
@@ -835,6 +855,7 @@ tape('population fallback tests', (test) => {
       {
         id: 12345,
         name: 'wof:name value',
+        name_aliases: [],
         place_type: 'country',
         lat: undefined,
         lon: undefined,
@@ -877,6 +898,7 @@ tape('population fallback tests', (test) => {
       {
         id: 12345,
         name: 'wof:name value',
+        name_aliases: [],
         place_type: 'country',
         lat: undefined,
         lon: undefined,
@@ -918,6 +940,7 @@ tape('population fallback tests', (test) => {
       {
         id: 12345,
         name: 'wof:name value',
+        name_aliases: [],
         place_type: 'country',
         lat: undefined,
         lon: undefined,
@@ -958,6 +981,7 @@ tape('population fallback tests', (test) => {
       {
         id: 12345,
         name: 'wof:name value',
+        name_aliases: [],
         place_type: 'country',
         lat: undefined,
         lon: undefined,
@@ -997,6 +1021,7 @@ tape('population fallback tests', (test) => {
       {
         id: 12345,
         name: 'wof:name value',
+        name_aliases: [],
         place_type: 'country',
         lat: undefined,
         lon: undefined,
@@ -1035,6 +1060,7 @@ tape('population fallback tests', (test) => {
       {
         id: 12345,
         name: 'wof:name value',
+        name_aliases: [],
         place_type: 'country',
         lat: undefined,
         lon: undefined,
@@ -1072,6 +1098,7 @@ tape('population fallback tests', (test) => {
       {
         id: 12345,
         name: 'wof:name value',
+        name_aliases: [],
         place_type: 'country',
         lat: undefined,
         lon: undefined,
@@ -1108,6 +1135,7 @@ tape('population fallback tests', (test) => {
       {
         id: 12345,
         name: 'wof:name value',
+        name_aliases: [],
         place_type: 'country',
         lat: undefined,
         lon: undefined,
@@ -1143,6 +1171,7 @@ tape('population fallback tests', (test) => {
       {
         id: 12345,
         name: 'wof:name value',
+        name_aliases: [],
         place_type: 'country',
         lat: undefined,
         lon: undefined,
@@ -1177,6 +1206,7 @@ tape('population fallback tests', (test) => {
       {
         id: 12345,
         name: 'wof:name value',
+        name_aliases: [],
         place_type: 'country',
         lat: undefined,
         lon: undefined,
@@ -1210,6 +1240,7 @@ tape('population fallback tests', (test) => {
       {
         id: 12345,
         name: 'wof:name value',
+        name_aliases: [],
         place_type: 'country',
         lat: undefined,
         lon: undefined,
@@ -1254,6 +1285,7 @@ tape('population fallback tests', (test) => {
       {
         id: 12345,
         name: 'wof:name value',
+        name_aliases: [],
         place_type: 'country',
         lat: undefined,
         lon: undefined,
@@ -1298,6 +1330,7 @@ tape('population fallback tests', (test) => {
       {
         id: 12345,
         name: 'wof:name value',
+        name_aliases: [],
         place_type: 'country',
         lat: undefined,
         lon: undefined,
@@ -1346,6 +1379,7 @@ tape('negative population fallback tests', (test) => {
       {
         id: 12345,
         name: 'wof:name value',
+        name_aliases: [],
         place_type: 'country',
         lat: undefined,
         lon: undefined,
@@ -1389,6 +1423,7 @@ tape('negative population fallback tests', (test) => {
       {
         id: 12345,
         name: 'wof:name value',
+        name_aliases: [],
         place_type: 'country',
         lat: undefined,
         lon: undefined,
@@ -1431,6 +1466,7 @@ tape('negative population fallback tests', (test) => {
       {
         id: 12345,
         name: 'wof:name value',
+        name_aliases: [],
         place_type: 'country',
         lat: undefined,
         lon: undefined,
@@ -1472,6 +1508,7 @@ tape('negative population fallback tests', (test) => {
       {
         id: 12345,
         name: 'wof:name value',
+        name_aliases: [],
         place_type: 'country',
         lat: undefined,
         lon: undefined,
@@ -1512,6 +1549,7 @@ tape('negative population fallback tests', (test) => {
       {
         id: 12345,
         name: 'wof:name value',
+        name_aliases: [],
         place_type: 'country',
         lat: undefined,
         lon: undefined,
@@ -1551,6 +1589,7 @@ tape('negative population fallback tests', (test) => {
       {
         id: 12345,
         name: 'wof:name value',
+        name_aliases: [],
         place_type: 'country',
         lat: undefined,
         lon: undefined,
@@ -1589,6 +1628,7 @@ tape('negative population fallback tests', (test) => {
       {
         id: 12345,
         name: 'wof:name value',
+        name_aliases: [],
         place_type: 'country',
         lat: undefined,
         lon: undefined,
@@ -1626,6 +1666,7 @@ tape('negative population fallback tests', (test) => {
       {
         id: 12345,
         name: 'wof:name value',
+        name_aliases: [],
         place_type: 'country',
         lat: undefined,
         lon: undefined,
@@ -1662,6 +1703,7 @@ tape('negative population fallback tests', (test) => {
       {
         id: 12345,
         name: 'wof:name value',
+        name_aliases: [],
         place_type: 'country',
         lat: undefined,
         lon: undefined,
@@ -1697,6 +1739,7 @@ tape('negative population fallback tests', (test) => {
       {
         id: 12345,
         name: 'wof:name value',
+        name_aliases: [],
         place_type: 'country',
         lat: undefined,
         lon: undefined,
@@ -1731,6 +1774,7 @@ tape('negative population fallback tests', (test) => {
       {
         id: 12345,
         name: 'wof:name value',
+        name_aliases: [],
         place_type: 'country',
         lat: undefined,
         lon: undefined,
@@ -1748,6 +1792,42 @@ tape('negative population fallback tests', (test) => {
     });
 
   });
+
+  test.test('name alias fields should return populate name_aliases array', function (t) {
+    var input = [
+      {
+        id: 23456,
+        properties: {
+          'name:eng_x_preferred': ['preferred1', 'preferred2', 'preferred1'],
+          'name:eng_x_variant': ['variant1', 'variant2', 'variant1'],
+          'name:eng_x_colloquial': ['colloquial1', 'colloquial2', 'colloquial1']
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 23456,
+        name: undefined,
+        name_aliases: ['preferred1', 'preferred2', 'variant1', 'variant2'],
+        place_type: undefined,
+        lat: undefined,
+        lon: undefined,
+        population: undefined,
+        popularity: undefined,
+        abbreviation: undefined,
+        bounding_box: undefined,
+        hierarchies: []
+      }
+    ];
+
+    test_stream(input, extractFields.create(), function (err, actual) {
+      t.deepEqual(actual, expected, 'stream should contain only objects with id and properties');
+      t.end();
+    });
+
+  });
+
   test.end();
 
 });

--- a/test/peliasDocGeneratorsTest.js
+++ b/test/peliasDocGeneratorsTest.js
@@ -22,6 +22,7 @@ tape('create', function(test) {
         1: {
           id: 1,
           name: 'record name',
+          name_aliases: [],
           lat: 12.121212,
           lon: 21.212121,
           place_type: place_type
@@ -73,6 +74,7 @@ tape('create', function(test) {
       1: {
         id: 1,
         name: 'record name',
+        name_aliases: [],
         abbreviation: 'record abbreviation',
         lat: 12.121212,
         lon: 21.212121,
@@ -116,6 +118,7 @@ tape('create', function(test) {
       1: {
         id: 1,
         name: 'record name',
+        name_aliases: [],
         abbreviation: 'XY',
         lat: 12.121212,
         lon: 21.212121,
@@ -159,6 +162,7 @@ tape('create', function(test) {
       1: {
         id: 1,
         name: 'record name',
+        name_aliases: [],
         abbreviation: 'PR',
         lat: 12.121212,
         lon: 21.212121,
@@ -202,6 +206,7 @@ tape('create', function(test) {
       1: {
         id: 1,
         name: 'record name',
+        name_aliases: [],
         abbreviation: 'FR',
         lat: 12.121212,
         lon: 21.212121,
@@ -245,6 +250,7 @@ tape('create', function(test) {
       1: {
         id: 1,
         name: 'name 1',
+        name_aliases: [],
         lat: 12.121212,
         lon: 21.212121,
         bounding_box: '12.121212,21.212121,13.131313,31.313131',
@@ -281,7 +287,8 @@ tape('create', function(test) {
     var wofRecords = {
      1: {
        id: 1,
-       name: 'name 1',
+      name: 'name 1',
+      name_aliases: [],
        lat: 12.121212,
        lon: 21.212121,
        place_type: 'continent'
@@ -353,6 +360,7 @@ tape('create', function(test) {
       1: {
         id: 1,
         name: 'United States',
+        name_aliases: [],
         lat: 12.121212,
         lon: 21.212121,
         place_type: 'country',
@@ -396,6 +404,7 @@ tape('create', function(test) {
       1: {
         id: 1,
         name: 'United States',
+        name_aliases: [],
         lat: 12.121212,
         lon: 21.212121,
         place_type: 'country',
@@ -440,6 +449,7 @@ tape('create', function(test) {
       1: {
         id: 1,
         name: 'United States',
+        name_aliases: [],
         lat: 12.121212,
         lon: 21.212121,
         place_type: 'country',
@@ -483,6 +493,7 @@ tape('create', function(test) {
       1: {
         id: 1,
         name: 'United States',
+        name_aliases: [],
         lat: 12.121212,
         lon: 21.212121,
         place_type: 'country',
@@ -522,11 +533,64 @@ tape('create', function(test) {
 
   });
 
+  test.test('name aliases should be set on doc', function (t) {
+    var wofRecords = {
+      1: {
+        id: 1,
+        name: 'United States',
+        name_aliases: [
+          'preferred1', 'preferred2',
+          'variant1', 'variant2'
+        ],
+        lat: 12.121212,
+        lon: 21.212121,
+        place_type: 'country',
+        abbreviation: 'US',
+        popularity: 87654
+      }
+    };
+
+    // extract all the values from wofRecords to an array since that's how test_stream works
+    // sure, this could be done with map, but this is clearer
+    var input = [
+      wofRecords['1']
+    ];
+
+    var expected = [
+      new Document('whosonfirst', 'country', '1')
+        .setName('default', 'United States')
+        .setNameAlias('default', 'preferred1')
+        .setNameAlias('default', 'preferred2')
+        .setNameAlias('default', 'variant1')
+        .setNameAlias('default', 'variant2')
+        .setCentroid({ lat: 12.121212, lon: 21.212121 })
+        .addParent('country', 'United States', '1', 'USA')
+        .setPopularity(87654)
+    ];
+
+    var hierarchies_finder = function () {
+      return [
+        [
+          wofRecords['1']
+        ]
+      ];
+    };
+
+    var docGenerator = peliasDocGenerators.create(hierarchies_finder);
+
+    test_stream(input, docGenerator, function (err, actual) {
+      t.deepEqual(actual, expected, 'population should not be set');
+      t.end();
+    });
+
+  });
+
   test.test('a document should be created for each available hierarchy', function(t) {
     var wofRecords = {
       1: {
         id: 1,
         name: 'neighbourhood name',
+        name_aliases: [],
         lat: 12.121212,
         lon: 21.212121,
         place_type: 'neighbourhood'
@@ -534,6 +598,7 @@ tape('create', function(test) {
       2: {
         id: 2,
         name: 'country name 1',
+        name_aliases: [],
         lat: 13.131313,
         lon: 31.313131,
         place_type: 'country'
@@ -541,6 +606,7 @@ tape('create', function(test) {
       3: {
         id: 3,
         name: 'country name 2',
+        name_aliases: [],
         lat: 14.141414,
         lon: 41.414141,
         place_type: 'country'

--- a/test/readStreamTest.js
+++ b/test/readStreamTest.js
@@ -78,6 +78,7 @@ tape('readStream', (test) => {
           '123': {
             id: 123,
             name: 'name 1',
+            name_aliases: [],
             place_type: 'place type 1',
             lat: 12.121212,
             lon: 21.212121,
@@ -92,6 +93,7 @@ tape('readStream', (test) => {
           '456': {
             id: 456,
             name: 'name 2',
+            name_aliases: [],
             place_type: 'place type 2',
             lat: 13.131313,
             lon: 31.313131,
@@ -231,6 +233,7 @@ tape('readStream', (test) => {
             '421302191': {
               id: 421302191,
               name: 'name 421302191',
+              name_aliases: [],
               abbreviation: undefined,
               place_type: undefined,
               lat: 45.240295,


### PR DESCRIPTION
Index `name:eng_x_preferred` and `name:eng_x_variant` as aliases for `name.default`.

Today I was trying to search for [Koh Samui](https://spelunker.whosonfirst.org/id/102024421/) (the Thai island) but was unable to find it in Pelias.

"Koh" in Thai means island, and is sometimes also spelled "Ko", although from my experience it's less common.
Without this PR it's not possible to find any Thai islands in Pelias using the prefix "Koh".

This will also hopefully have other benefits, our current method (`wof:label OR wof:name`) of finding the name is a bit naive and probably misses out a bunch of useful aliases.
