### PR TITLE
update sqlite_common.js to escape quotes according to RFC 4180

### DIFF
--- a/utils/sqlite_common.js
+++ b/utils/sqlite_common.js
@@ -28,8 +28,8 @@ module.exports.MetaDataFiles = function MetaDataFiles( metaDir ){
     streams[row.placetype].write( keys.map(key => {
       // quote fields containing comma or newline, escape internal quotes
       // https://gist.github.com/getify/3667624
-      if( /[,\n]/.test( row[key] ) ) {
-        return '"' + row[key].replace(/\\([\s\S])|(")/g,'\\$1$2') + '"';
+      if ( /[",\n]/.test( row[key] ) ) {
+        return '"' + row[key].replace(/""([\s\S])|(")/g, '"$1$2') + '"';
       }
       return row[key];
     }).join(',') + '\n' );


### PR DESCRIPTION
The `utils/sqlite_common.js` script contains a hand-written CSV writer function used to write WOF meta files.

When I wrote it I assumed that the escape character for a double-quote was a backslash, turns out according to RFC 4180 it's actually correct to encode a literal double-quote as two repeated double-quotes.

I tested the meta files with https://github.com/Clever/csvlint

Prior to this PR:
```
Warning: not using defaults, may not validate CSV to RFC 4180
Record #150376 has error: bare " in non-quoted-field
```

After this PR the CSV file is showing as valid.

This never caused issues in the past, so I guess that new data has been introduced since the last bundles were published which contain some bytes which trigger this issue.

Additionally, this enforces that any fields containing a double-quote are wrapped in double-quotes.