### PR TITLE
fix(sqlite): remove obsolete index creation

### DIFF
--- a/src/components/sqliteStream.js
+++ b/src/components/sqliteStream.js
@@ -6,13 +6,6 @@ class SQLiteStream extends Readable {
   constructor(dbPath, sql) {
     super({ objectMode: true, autoDestroy: true, highWaterMark: 32 });
 
-    // ensure indices exist
-    // note: this can be removed once the upstream PR is merged:
-    // https://github.com/whosonfirst/go-whosonfirst-sqlite-features/pull/4
-    new Sqlite3(dbPath)
-      .exec('CREATE INDEX IF NOT EXISTS spr_obsolete ON spr (is_deprecated, is_superseded)')
-      .close();
-
     this._db = new Sqlite3(dbPath, { readonly: true });
     this._iterator = this._db.prepare(sql).iterate();
     this.on('error', (e) => { logger.error(e); });


### PR DESCRIPTION
Turns out the `obsolete` index creation is not compatible with the PIP service.

In the case where the sqlite database does not yet have the `obsolete` index, all PIP workers will attempt to create it, and most will fail to obtain a write lock.

This causes the workers, and thus the whole PIP service, to shut down without updating the SQLite db. Therefore no progress can be made and the PIP service can never start.

It's likely this wasn't caught during development because the SQLite database used for testing already had the index. However, the databases downloaded from dist.whosonfirst.org do not _yet_ have it.

While this index is important for performance when reading from the SQLite database, it will eventually make its way into the official files.

In the meantime, the `dataHost` parameter in `pelias.json` can be used in combination with a custom SQLite db with the index already created, if max performance is desired.