### PR TITLE
catch and log pelias/model errors

### DIFF
--- a/src/peliasDocGenerators.js
+++ b/src/peliasDocGenerators.js
@@ -1,8 +1,9 @@
-var through2 = require('through2');
-var _ = require('lodash');
-var iso3166 = require('iso3166-1');
+const through2 = require('through2');
+const _ = require('lodash');
+const iso3166 = require('iso3166-1');
+const log = require('pelias-logger').get('openstreetmap');
 
-var Document = require('pelias-model').Document;
+const Document = require('pelias-model').Document;
 
 module.exports = {};
 
@@ -131,14 +132,19 @@ module.exports.create = function(hierarchy_finder) {
     // if there are no hierarchies, then just return the doc as-is
     var hierarchies = hierarchy_finder(record);
 
-    if (hierarchies && hierarchies.length > 0) {
-      hierarchies.forEach(function(hierarchy) {
-        this.push(setupDocument(record, hierarchy));
-      }, this);
+    try {
+      if (hierarchies && hierarchies.length > 0) {
+        hierarchies.forEach(function(hierarchy) {
+          this.push(setupDocument(record, hierarchy));
+        }, this);
 
-    } else {
-      this.push(setupDocument(record));
-
+      } else {
+        this.push(setupDocument(record));
+      }
+    }
+    catch (e) {
+      log.error(`doc generator error: ${e.message}`);
+      log.error(JSON.stringify(record, null, 2));
     }
 
     next();

--- a/test/peliasDocGeneratorsTest.js
+++ b/test/peliasDocGeneratorsTest.js
@@ -653,6 +653,29 @@ tape('create', function(test) {
     });
 
   });
+
+  test.test('errors: should catch model errors and continue', function (t) {
+
+    // trigger model to throw an exception by providing an invalid name
+    var input = [{
+      id: 1,
+      name: 'http://urls_not_allowed_here',
+      place_type: 'country'
+    }];
+
+    t.doesNotThrow(() => {
+      var docGenerator = peliasDocGenerators.create(() => {
+        return [[input[0]]];
+      });
+
+      test_stream(input, docGenerator, function (err, actual) {
+        t.deepEqual(actual, [], 'should throw error and continue');
+        t.end();
+      }, /should not match/, 'should catch + log model errors');
+    });
+
+  });
+
   test.end();
 
 });


### PR DESCRIPTION
It seems that this importer does not attempt to catch and log `pelias/model` errors as the other importers do.
This PR adds a `try/catch` block with logging to prevent the importer from terminating upon error.

resolves https://github.com/pelias/model/issues/116
related https://github.com/pelias/model/pull/115