### PR TITLE
add support for label:* properties

### DIFF
--- a/src/components/extractFields.js
+++ b/src/components/extractFields.js
@@ -63,23 +63,48 @@ function getBoundingBox(properties) {
   }
 }
 
-function getName(properties) {
-  if (properties.hasOwnProperty('wof:label')) {
-    return properties['wof:label'];
-  } else {
-    return properties['wof:name'];
+// get an array of language codes spoken at this location
+function getLanguages(properties) {
+  if (!Array.isArray(properties['wof:lang_x_official'])) {
+    return [];
   }
+  return properties['wof:lang_x_official']
+    .filter(l => (typeof l === 'string' && l.length === 3))
+    .map(l => l.toLowerCase());
 }
 
-function getNameAliases(properties) {
-  let aliases = [];
-  name_alias_fields.forEach(field => {
-    if( Array.isArray(properties[field]) && properties[field].length ){
-      aliases = aliases.concat(properties[field]);
+// convenience function to safely concat array fields
+function concatArrayFields(properties, fields){
+  let arr = [];
+  fields.forEach(field => {
+    if (Array.isArray(properties[field]) && properties[field].length) {
+      arr = arr.concat(properties[field]);
     }
   });
   // dedupe array
-  return aliases.filter((item, pos, self) => self.indexOf(item) === pos);
+  return arr.filter((item, pos, self) => self.indexOf(item) === pos);
+}
+
+// note: 'wof:label' has been officially deprecated
+// see: https://github.com/whosonfirst-data/whosonfirst-data/issues/1540
+// see: https://github.com/whosonfirst-data/whosonfirst-data/pull/1548
+function getName(properties) {
+
+  // look for a label in one of the official languages
+  let langs = getLanguages(properties);
+  if (!langs.includes('eng')) { langs.push('eng'); } // otherwise fallback to english
+
+  // find all relevant labels
+  let labelFields = langs.map(l => `label:${l}_x_preferred_longname`);
+  let labels = concatArrayFields(properties, labelFields);
+  if( labels.length ){ return labels[0]; }
+
+  // fall back to the deprecated 'wof:label' property
+  if (properties.hasOwnProperty('wof:label')) {
+    return properties['wof:label'];
+  }
+  // use the 'wof:name' property
+  return properties['wof:name'];
 }
 
 function getAbbreviation(properties) {
@@ -121,7 +146,7 @@ module.exports.create = function map_fields_stream() {
     var record = {
       id: json_object.id,
       name: getName(json_object.properties),
-      name_aliases: getNameAliases(json_object.properties),
+      name_aliases: concatArrayFields(json_object.properties, name_alias_fields),
       abbreviation: getAbbreviation(json_object.properties),
       place_type: json_object.properties['wof:placetype'],
       lat: getLat(json_object.properties),

--- a/test/components/extractFieldsTest.js
+++ b/test/components/extractFieldsTest.js
@@ -469,6 +469,123 @@ tape('readStreamComponents', function(test) {
     });
   });
 
+  test.test('label:{lang}_x_preferred_longname should be used for name when both it and eng label are available', function (t) {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:label': 'wof:label value',
+          'label:eng_x_preferred_longname': ['label:eng_x_preferred_longname value'],
+          'label:spa_x_preferred_longname': ['label:spa_x_preferred_longname value'],
+          'wof:lang_x_official': ['spa'],
+          'geom:latitude': 12.121212,
+          'geom:longitude': 21.212121,
+          'lbl:bbox': ''
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'label:spa_x_preferred_longname value',
+        name_aliases: [],
+        place_type: undefined,
+        lat: 12.121212,
+        lon: 21.212121,
+        population: undefined,
+        popularity: undefined,
+        bounding_box: '',
+        abbreviation: undefined,
+        hierarchies: []
+      }
+    ];
+
+    test_stream(input, extractFields.create(), function (err, actual) {
+      t.deepEqual(actual, expected, 'label:eng_x_preferred_longname is used for name');
+      t.end();
+    });
+
+  });
+
+  test.test('label:eng_x_preferred_longname should be used for name when official language label unavailable', function (t) {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:label': 'wof:label value',
+          'label:eng_x_preferred_longname': ['label:eng_x_preferred_longname value'],
+          'wof:lang_x_official': ['spa'],
+          'geom:latitude': 12.121212,
+          'geom:longitude': 21.212121,
+          'lbl:bbox': ''
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'label:eng_x_preferred_longname value',
+        name_aliases: [],
+        place_type: undefined,
+        lat: 12.121212,
+        lon: 21.212121,
+        population: undefined,
+        popularity: undefined,
+        bounding_box: '',
+        abbreviation: undefined,
+        hierarchies: []
+      }
+    ];
+
+    test_stream(input, extractFields.create(), function (err, actual) {
+      t.deepEqual(actual, expected, 'label:eng_x_preferred_longname is used for name');
+      t.end();
+    });
+
+  });
+
+  test.test('label:eng_x_preferred_longname should be used for name when both it and wof:label are available', function (t) {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:label': 'wof:label value',
+          'label:eng_x_preferred_longname': ['label:eng_x_preferred_longname value'],
+          'geom:latitude': 12.121212,
+          'geom:longitude': 21.212121,
+          'lbl:bbox': ''
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'label:eng_x_preferred_longname value',
+        name_aliases: [],
+        place_type: undefined,
+        lat: 12.121212,
+        lon: 21.212121,
+        population: undefined,
+        popularity: undefined,
+        bounding_box: '',
+        abbreviation: undefined,
+        hierarchies: []
+      }
+    ];
+
+    test_stream(input, extractFields.create(), function (err, actual) {
+      t.deepEqual(actual, expected, 'label:eng_x_preferred_longname is used for name');
+      t.end();
+    });
+
+  });
+
   test.test('wof:label should be used for name when both it and wof:name are available', function(t) {
     var input = [
       {


### PR DESCRIPTION
This PR is to action the deprecation of the `wof:label` property in favour of `label:{lang}_x_preferred_longname`.

I've asked for some clarification on the expected workflow to migrate the properties in https://github.com/whosonfirst-data/whosonfirst-data/issues/1540#issuecomment-481630407, so hopefully we can get some confirmation before merging this.

For more information see the discussions linked below:

Related issues from WOF:
- https://github.com/whosonfirst-data/whosonfirst-data/issues/1540
- https://github.com/whosonfirst-data/whosonfirst-data/pull/1548