### PR TITLE
added support for label:${lang}_x_preferred

### DIFF
--- a/src/components/extractFields.js
+++ b/src/components/extractFields.js
@@ -22,7 +22,8 @@ const population_hierarchy = [
 const NAME_ALIAS_FIELDS = [
   'name:%s_x_preferred',
   'name:%s_x_variant',
-  'label:%s_x_preferred_longname'
+  'label:%s_x_preferred_longname',
+  'label:%s_x_preferred'
 ];
 
 // this function is used to verify that a US county QS altname is available
@@ -89,6 +90,7 @@ function concatArrayFields(properties, fields){
 }
 
 // note: 'wof:label' has been officially deprecated
+// see: https://github.com/whosonfirst-data/whosonfirst-data/issues/1540#issuecomment-481824475
 // see: https://github.com/whosonfirst-data/whosonfirst-data/issues/1540
 // see: https://github.com/whosonfirst-data/whosonfirst-data/pull/1548
 function getName(properties) {
@@ -99,6 +101,7 @@ function getName(properties) {
 
   // find the most relevant label
   let labelFields = langs.map(l => `label:${l}_x_preferred_longname`);
+  labelFields = labelFields.concat(langs.map(l => `label:${l}_x_preferred`));
   let labels = concatArrayFields(properties, labelFields);
   if( labels.length ){ return labels[0]; }
 

--- a/test/components/extractFieldsTest.js
+++ b/test/components/extractFieldsTest.js
@@ -551,7 +551,7 @@ tape('readStreamComponents', function(test) {
 
   });
 
-  test.test('label:eng_x_preferred_longname should be used for name when both it and wof:label are available', function (t) {
+  test.test('label:eng_x_preferred_longname when eng_x_preferred exists', function (t) {
     var input = [
       {
         id: 12345,
@@ -559,6 +559,7 @@ tape('readStreamComponents', function(test) {
           'wof:name': 'wof:name value',
           'wof:label': 'wof:label value',
           'label:eng_x_preferred_longname': ['label:eng_x_preferred_longname value'],
+          'label:eng_x_preferred': ['label:eng_x_preferred value'],
           'geom:latitude': 12.121212,
           'geom:longitude': 21.212121,
           'lbl:bbox': ''
@@ -570,7 +571,10 @@ tape('readStreamComponents', function(test) {
       {
         id: 12345,
         name: 'label:eng_x_preferred_longname value',
-        name_aliases: ['label:eng_x_preferred_longname value'],
+        name_aliases: [
+          'label:eng_x_preferred_longname value',
+          'label:eng_x_preferred value'
+        ],
         place_type: undefined,
         lat: 12.121212,
         lon: 21.212121,
@@ -584,6 +588,44 @@ tape('readStreamComponents', function(test) {
 
     test_stream(input, extractFields.create(), function (err, actual) {
       t.deepEqual(actual, expected, 'label:eng_x_preferred_longname is used for name');
+      t.end();
+    });
+
+  });
+
+  test.test('label:eng_x_preferred should be used for name when both it and wof:label are available', function (t) {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'wof:label': 'wof:label value',
+          'label:eng_x_preferred': ['label:eng_x_preferred value'],
+          'geom:latitude': 12.121212,
+          'geom:longitude': 21.212121,
+          'lbl:bbox': ''
+        }
+      }
+    ];
+
+    var expected = [
+      {
+        id: 12345,
+        name: 'label:eng_x_preferred value',
+        name_aliases: ['label:eng_x_preferred value'],
+        place_type: undefined,
+        lat: 12.121212,
+        lon: 21.212121,
+        population: undefined,
+        popularity: undefined,
+        bounding_box: '',
+        abbreviation: undefined,
+        hierarchies: []
+      }
+    ];
+
+    test_stream(input, extractFields.create(), function (err, actual) {
+      t.deepEqual(actual, expected, 'label:eng_x_preferred is used for name');
       t.end();
     });
 


### PR DESCRIPTION
Actioning feedback in: https://github.com/whosonfirst-data/whosonfirst-data/issues/1540#issuecomment-481824475

This PR adds support for `label:${lang}_x_preferred` for names and aliases.