### PR TITLE
Convert string lat/lon values to numbers

### DIFF
--- a/src/components/extractFields.js
+++ b/src/components/extractFields.js
@@ -43,20 +43,23 @@ function getPopulation( props ) {
           find((val) => { return val >= 0; } );
 }
 
-function getLat(properties) {
-  if (properties['lbl:latitude']) {
-    return properties['lbl:latitude'];
+// return number or undefined
+function getNumber(value) {
+  const numericValue = parseFloat(value);
+
+  if (isNaN(numericValue) || !isFinite(numericValue)) {
+    return undefined;
   } else {
-    return properties['geom:latitude'];
+    return numericValue;
   }
 }
 
+function getLat(properties) {
+  return getNumber(properties['lbl:latitude']) || getNumber(properties['geom:latitude']);
+}
+
 function getLon(properties) {
-  if (properties['lbl:longitude']) {
-    return properties['lbl:longitude'];
-  } else {
-    return properties['geom:longitude'];
-  }
+  return getNumber(properties['lbl:longitude']) || getNumber(properties['geom:longitude']);
 }
 
 function getBoundingBox(properties) {

--- a/test/components/extractFieldsTest.js
+++ b/test/components/extractFieldsTest.js
@@ -259,6 +259,25 @@ tape('readStreamComponents', function(test) {
 
   });
 
+  test.test('latitude and longitude strings should be converted to numbers', function(t) {
+    var input = [
+      {
+        id: 12345,
+        properties: {
+          'wof:name': 'wof:name value',
+          'geom:latitude': '12.121212',
+          'geom:longitude': '21.212121'
+        }
+      }
+    ];
+
+    test_stream(input, extractFields.create(), function(err, actual) {
+      t.deepEqual(actual[0].lat, 12.121212, 'lat is a number');
+      t.deepEqual(actual[0].lon, 21.212121, 'lon is a number');
+      t.end();
+    });
+  });
+
   test.test('label centroid should take precedence over math centroid', function(t) {
     var input = [
       {


### PR DESCRIPTION
While Elasticsearch ultimately does not care about whether lat/lon values are numbers or strings, other parts of code do care, specifically detecting whether records are on Null Island, and therefore likely invalid.

In particular, the work in https://github.com/pelias/whosonfirst/pull/370 assumed only the string value '0.0' would be possible for lat/lons.

By converting to numbers, we should finally be correctly filtering out the many postal codes that are on Null Island.

Connects https://github.com/pelias/pelias/issues/692