### PR TITLE
fix(NullIsland): Detect string values for Null Island

### DIFF
--- a/src/components/isNotNullIslandRelated.js
+++ b/src/components/isNotNullIslandRelated.js
@@ -1,13 +1,23 @@
 const filter = require('through2-filter');
 const _ = require('lodash');
 
+// return number or undefined
+function getNumber(value) {
+  const numericValue = parseFloat(value);
+
+  if (isNaN(numericValue) || !isFinite(numericValue)) {
+    return undefined;
+  } else {
+    return numericValue;
+  }
+}
+
 function isNullIsland(record) {
   return _.toNumber(record.id) === 1;
 }
 
 function isOnNullIsland(record) {
-  return (record.geom_latitude === '0.0' || record.geom_latitude === 0) &&
-         (record.geom_longitude === '0.0' || record.geom_longitude === 0);
+  return getNumber(record.geom_latitude) === 0 && getNumber(record.geom_longitude) === 0;
 }
 
 function isPostalCodeOnNullIsland(record) {

--- a/test/components/isNotNullIslandRelated.js
+++ b/test/components/isNotNullIslandRelated.js
@@ -34,11 +34,7 @@ tape('isNotNullIslandRelated tests', (test) => {
     });
 
   });
-  test.end();
 
-});
-
-tape('recordHasName', (test) => {
   test.test('non-postalcode placetype records should pass even if lat/lon is 0/0', (t) => {
     const input = {
       placetype: 'non-postalcode',
@@ -109,11 +105,24 @@ tape('recordHasName', (test) => {
 
   });
 
-  test.test('postalcode placetype records should not pass even if lat/lon is 0/0', (t) => {
+  test.test('postalcode placetype records should not pass if lat/lon is 0/0 (number)', (t) => {
     const input = {
       placetype: 'postalcode',
       geom_latitude: 0,
       geom_longitude: 0
+    };
+
+    test_stream([input], isNotNullIslandRelated.create(), (err, actual) => {
+      t.deepEqual(actual, [], 'should have returned true');
+      t.end();
+    });
+  });
+
+  test.test('postalcode placetype records should not pass if lat/lon is 0/0 (string)', (t) => {
+    const input = {
+      placetype: 'postalcode',
+      geom_latitude: '0.0',
+      geom_longitude: '0.0'
     };
 
     test_stream([input], isNotNullIslandRelated.create(), (err, actual) => {


### PR DESCRIPTION
The stream component to filter out Null Island related records was checking against a single string value that represents 0, when of course there are many.

By converting the field into a number and then comparing with 0, Null Island detection is made more robust.

Connects https://github.com/pelias/whosonfirst/pull/370
Connects https://github.com/pelias/pelias/issues/692