### PR TITLE
feat(deps): Use carat range for combined-stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "async": "^2.5.0",
     "better-sqlite3": "^5.0.0",
-    "combined-stream": "1.0.5",
+    "combined-stream": "^1.0.5",
     "csv-stream": "^0.2.0",
     "download-file-sync": "^1.0.4",
     "fs-extra": "^8.0.0",


### PR DESCRIPTION
As mentioned in https://github.com/pelias/openaddresses/pull/343, we were a bit nervous about a behavior change introduced in combined-stream 1.0.7.

However, as discovered in https://github.com/felixge/node-combined-stream/issues/40 it's a bugfix that makes previously unrecommended use of the library finally break.

The code in this repository is already using the library in the recommended way, and isn't affected, so we might as well stay with the latest version.

Closes https://github.com/pelias/whosonfirst/pull/442