### PR TITLE
feat(sqlite): Gracefully handle issues creating sqlite indices

### DIFF
--- a/src/components/sqliteStream.js
+++ b/src/components/sqliteStream.js
@@ -2,16 +2,28 @@ const Readable = require('stream').Readable;
 const Sqlite3 = require('better-sqlite3');
 const logger = require('pelias-logger').get('whosonfirst:sqliteStream');
 
+// attempt to create index to improve read performance
+//
+// catch all failures since the PIP service will have several processes all
+// trying to acquire a write lock on the DB, and only one will succeed
+//
+// note: can be removed once the upstream PR is merged and all data on
+// dist.whosonfirst.org is updated:
+// https://github.com/whosonfirst/go-whosonfirst-sqlite-features/pull/4
+function createIndex(dbPath) {
+  try {
+    new Sqlite3(dbPath)
+      .exec('CREATE INDEX IF NOT EXISTS spr_obsolete ON spr (is_deprecated, is_superseded)')
+      .close();
+  } catch (e){
+  }
+}
+
 class SQLiteStream extends Readable {
   constructor(dbPath, sql) {
     super({ objectMode: true, autoDestroy: true, highWaterMark: 32 });
 
-    // ensure indices exist
-    // note: this can be removed once the upstream PR is merged:
-    // https://github.com/whosonfirst/go-whosonfirst-sqlite-features/pull/4
-    new Sqlite3(dbPath)
-      .exec('CREATE INDEX IF NOT EXISTS spr_obsolete ON spr (is_deprecated, is_superseded)')
-      .close();
+    createIndex(dbPath);
 
     this._db = new Sqlite3(dbPath, { readonly: true });
     this._iterator = this._db.prepare(sql).iterate();


### PR DESCRIPTION
The creation of the `spr_obsolete` index is problematic for the PIP service and any of the admin lookup workers running in the importers.

Because there are always multiple processes doing admin lookup, and each one tries to create the index if it doesn't exist, most end up failing. SQLite only allows a single write lock on the DB, so all but one will fail to achieve it.

However, in my testing, all it takes to solve this gracefully is to wrap the index creation in a try/catch block. The index will be created by one of the worker processes, and all subsequent queries appear to have the performance improvements of the index (about 30-50% faster time to
load admin data).

Supersedes https://github.com/pelias/whosonfirst/pull/431
Fixes https://github.com/pelias/whosonfirst/issues/454
Connects https://github.com/pelias/whosonfirst/issues/453 (we should not actually remove the index creation quite yet, the `whosonfirst-data-latest` file does not have the index)