### PR TITLE
anchor WOF_NAMES_REGEX

### DIFF
--- a/src/components/extractFields.js
+++ b/src/components/extractFields.js
@@ -27,7 +27,7 @@ const NAME_ALIAS_FIELDS = [
   'label:%s_x_preferred'
 ];
 
-const WOF_NAMES_REGEX = /(name|label):[a-z]{3}_x_(preferred|variant)/;
+const WOF_NAMES_REGEX = /^(name|label):[a-z]{3}_x_(preferred|variant)$/;
 
 // this function is used to verify that a US county QS altname is available
 function isUsCounty(base_record, wof_country, qs_a2_alt) {
@@ -136,7 +136,7 @@ function getNameAliases(properties) {
 
 function getMultiLangNames(defaultName, properties) {
   return Object.keys(properties)
-    .filter(key => WOF_NAMES_REGEX.test(key)) // get only name:.* keys
+    .filter(key => WOF_NAMES_REGEX.test(key)) // get only matching keys
     .map(key => {
       return {
         key: key.substring(key.indexOf(':') + 1, key.indexOf(':') + 4), // get the iso part of the key name:iso_x_preferred

--- a/test/components/extractFieldsTest.js
+++ b/test/components/extractFieldsTest.js
@@ -1055,5 +1055,30 @@ tape('multi-lang index test', (test) => {
     });
   });
 
+  test.test('WOF_NAMES_REGEX should be anchored (do not allow prefixes and suffixes)', function (t) {
+    var input = [
+      {
+        id: 54321,
+        properties: {
+          'name:fra_x_preferred': ['example1'],
+          'name:fra_x_preferred_foo': ['example2'],
+          'foo_name:fra_x_preferred': ['example3'],
+          'label:fra_x_preferred': ['example4'],
+          'label:fra_x_preferred_foo': ['example5'],
+          'foo_label:fra_x_preferred': ['example6']
+        }
+      }
+    ];
+
+    const expected_name_langs = {
+      'fr': ['example1', 'example4']
+    };
+
+    test_stream(input, extractFields.create(), function (err, actual) {
+      t.deepEqual(actual[0].name_langs, expected_name_langs, 'should not have duplicates');
+      t.end();
+    });
+  });
+
   test.end();
 });


### PR DESCRIPTION
anchor WOF_NAMES_REGEX to prevent matching properties such as "label:eng_x_preferred_placetype"

I noticed that we are importing the `label:eng_x_preferred_placetype` property due to a regex error.