### PR TITLE
feat(deps): Remove node-version-checker

### DIFF
--- a/import.js
+++ b/import.js
@@ -4,13 +4,9 @@ var importStream = require('./src/importStream');
 var peliasDbclient = require( 'pelias-dbclient' );
 var peliasDocGenerators = require('./src/peliasDocGenerators');
 var hierarchyFinder = require('./src/hierarchyFinder');
-var version_checker = require('node-version-checker').default;
 var bundles = require('./src/bundleList');
 
 const logger = require( 'pelias-logger' ).get( 'whosonfirst' );
-
-// print a warning if an unsupported Node.JS version is used
-version_checker();
 
 // a cache of only admin records, to be used to fill the hierarchy
 // of other, lower admin records as well as venues

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@hapi/joi": "^15.0.0",
     "klaw-sync": "^6.0.0",
     "lodash": "^4.5.1",
-    "node-version-checker": "^2.0.0",
     "parallel-transform": "^1.1.0",
     "pelias-blacklist-stream": "^1.0.0",
     "pelias-config": "^4.0.0",


### PR DESCRIPTION
This module hasn't been updated in 4 years, and we don't use it in any of our other projects.
