### PR TITLE
Drop support for Node.js 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 notifications:
   email: false
 node_js:
-  - 8
   - 10
   - 12
 matrix:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pelias-whosonfirst",
   "version": "0.0.0-development",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "description": "Importer for Who's on First",
   "main": "index.js",


### PR DESCRIPTION
BREAKING CHANGE: Node.js 8 is no longer supported as it will reach [end of life](https://github.com/nodejs/Release#release-schedule) at the end of 2019.

Connects https://github.com/pelias/pelias/issues/837