### PR TITLE
feat(download): Filter out country-specific SQLite DBs

### DIFF
--- a/utils/download_sqlite_all.js
+++ b/utils/download_sqlite_all.js
@@ -26,6 +26,8 @@ function download(callback) {
     const content = JSON.parse(downloadFileSync(`${wofDataHost}/sqlite/inventory.json`))
        // Only latest compressed files
       .filter(e => e.name_compressed.indexOf('latest') >= 0)
+      // country-specific SQLite bundles are broken, filter them out for now
+      .filter(e => !e.name.match(/admin-..-/))
       // Postalcodes only when importPostalcodes is ture and without --admin-only arg
       .filter(e => e.name_compressed.indexOf('postalcode') < 0 ||
         (config.imports.whosonfirst.importPostalcodes && process.argv[2] !== '--admin-only'))


### PR DESCRIPTION
The country-specific SQLite DBs currently available for download from https://dist.whosonfirst.org have a few integrity issues. This causes problems in Pelias such as addresses in NYC or Berlin not having proper admin information.

The planet-wide SQLite DB, while a little out of date, is overall more valid.

While in the long term we probably want to utilize the country-specific DBs, for now it makes sense to filter them out.

Fixes https://github.com/pelias/whosonfirst/issues/469
Connects https://github.com/pelias/whosonfirst/issues/460
Fixes https://github.com/pelias/whosonfirst/issues/437