### PR TITLE
bzip2 to lbzip2 migration to use all CPU cores

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM pelias/baseimage
 
 # downloader apt dependencies
 # note: this is done in one command in order to keep down the size of intermediate containers
-RUN apt-get update && apt-get install -y autoconf automake libtool pkg-config python bzip2 unzip && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y autoconf automake libtool pkg-config python bzip2 lbzip2 unzip && rm -rf /var/lib/apt/lists/*
 
 # change working dir
 ENV WORKDIR /code/pelias/whosonfirst

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "async": "^3.0.1",
     "better-sqlite3": "^5.0.0",
     "combined-stream": "^1.0.5",
+    "command-exists": "^1.2.8",
     "csv-stream": "^0.2.0",
     "download-file-sync": "^1.0.4",
     "fs-extra": "^8.0.0",

--- a/utils/download_sqlite_all.js
+++ b/utils/download_sqlite_all.js
@@ -4,6 +4,7 @@ const fs = require('fs-extra');
 const os = require('os');
 const path = require('path');
 const downloadFileSync = require('download-file-sync');
+const commandExistsSync = require('command-exists').sync;
 
 const config = require('pelias-config').generate(require('../schema'));
 
@@ -50,9 +51,20 @@ function download(callback) {
   const generateCommand = (sqlite, directory) => {
     let extract;
     if (/\.db\.bz2$/.test(sqlite.name_compressed)) {
-      extract = `bunzip2`;
+	  //Check if we have lbzip2 installed
+      if ( commandExistsSync('lbzip2') ) { 
+		extract = `lbzip2`;
+		} else {
+		extract = `bunzip2`;
+	  };
     } else if(/\.db\.tar\.bz2$/.test(sqlite.name_compressed)) {
-      extract = `tar -xjO`;
+	  //Check if we have lbzip2 installed
+	  if ( commandExistsSync('lbzip2') ) { 
+	    //Aim tar to use lbzip2
+		extract = `tar -xO --use-compress-program=lbzip2`;
+		} else {
+		extract = `tar -xjO`;
+	  };
     } else {
       throw new Error('What is this extension ?!?');
     }

--- a/utils/sqlite_download.sh
+++ b/utils/sqlite_download.sh
@@ -25,9 +25,18 @@ REMOTE_PATH="${REMOTE}/${DB_FILENAME}.bz2"
 
 info() { echo -e "\e[33m[$1]\t\e[0m $2" >&2; }
 err() { echo -e "\e[31m[$1]\t\e[0m \e[91m$2\e[0m" >&2; }
+
+#Check if we have lbzip2 (https://lbzip2.org/) installed
+decompress_utility() {
+    if hash lbzip2 2>/dev/null; then
+        lbzip2 -d -f "${LOCAL_BZ2_PATH}" > "${LOCAL_DB_PATH}"
+    else
+        bunzip2 -f "${LOCAL_BZ2_PATH}" > "${LOCAL_DB_PATH}"
+    fi
+}
 extract_file() {
   info 'whosonfirst-sqlite-decompress' "${LOCAL_BZ2_PATH}"
-  bunzip2 -f "${LOCAL_BZ2_PATH}" > "${LOCAL_DB_PATH}"
+  decompress_utility
 }
 generate_timestamp() {
   printf "@" > "${LOCAL_TS_PATH}" # date command requires @ prefix


### PR DESCRIPTION
**Summary of changes:** 
1. If `lbzip2` installed on system we use it. If not, using legacy `bzip2`.
2. Updated `Dockerfile` to install `lbzip2`
3. Additional dependency:  `command-exists`




Tested `lbzip2` version on my machine for command `npm run download`. Results are below:

**Using lbzip2**


> 542.68user 101.13system **1:49.16**elapsed 589%CPU (0avgtext+0avgdata **210392**maxresident)k
> 201176inputs+15375728outputs (1001major+1221746minor)pagefault 0swaps



**Using bzip2**

> 526.88user 168.91system **3:01.95**elapsed 382%CPU (0avgtext+avgdata **48292**maxresident)k
> 91608inputs+15375736outputs (275major+70098minor)pagefaults 0swaps


Frankly speaking, speed results are not so different just because we use parallel download and parallel run of several instances of bzip2 ( `const simultaneousDownloads` in `download_data_all.js`, for example ). Memory consumption is just **4** times higher for lbzip2 (**200MB** vs **50MB**)

But reason why I start to investigate it is that in PiP there is hardcoded one single sqlite file `whosonfirst-data-latest.db` which extracted extremely slow by one CPU core when not using lbzip2.

Fixes #480