### PR TITLE
Fix ignoring dataHost and maxDownloads options

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The maximum number of files to download simultaneously. Higher values can be fas
 ### `imports.whosonfirst.dataHost`
 
 * Required: no
-* Default: `https://dist.whosonfirst.org/`
+* Default: `https://dist.whosonfirst.org`
 
 The location to download Who's on First data from. Changing this can be useful to use custom data, pin data to a specific date, etc.
 

--- a/utils/sqlite_download.sh
+++ b/utils/sqlite_download.sh
@@ -20,8 +20,7 @@ DB_FILENAME="$1"
 LOCAL_DB_PATH="$2"
 LOCAL_BZ2_PATH="$2.bz2"
 LOCAL_TS_PATH="${LOCAL_DB_PATH}.timestamp"
-REMOTE='https://dist.whosonfirst.org/sqlite'
-REMOTE_PATH="${REMOTE}/${DB_FILENAME}.bz2"
+REMOTE_PATH="$3/sqlite/${DB_FILENAME}.bz2"
 
 info() { echo -e "\e[33m[$1]\t\e[0m $2" >&2; }
 err() { echo -e "\e[31m[$1]\t\e[0m \e[91m$2\e[0m" >&2; }


### PR DESCRIPTION
Summary of changes:
1. Fix ignoring option `dataHost` while call `sqlite_download.sh`
2. Update README to show correct example of `dataHost` URL
3. Fix ignoring option `maxDownloads` in `sqlite_download.js`