### PR TITLE
fix(download): Use correct `lbzip2`

### DIFF
--- a/utils/download_sqlite_all.js
+++ b/utils/download_sqlite_all.js
@@ -53,14 +53,14 @@ function download(callback) {
     if (/\.db\.bz2$/.test(sqlite.name_compressed)) {
       // Check if we have lbzip2 installed
       if (commandExistsSync('lbzip2')) {
-        extract = 'lbzip';
+        extract = 'lbzip2';
       } else {
         extract = 'bunzip';
       }
     } else if (/\.db\.tar\.bz2$/.test(sqlite.name_compressed)) {
       // Check if we have lbzip2 installed
       if (commandExistsSync('lbzip2')) {
-        extract = 'tar -xO --use-compress-program=lbzip';
+        extract = 'tar -xO --use-compress-program=lbzip2';
       } else {
         extract = 'tar -xj';
       }


### PR DESCRIPTION
Looks like somehow the actual command name to use was missed in https://github.com/pelias/whosonfirst/pull/483, causing the traditional tar bundle downloads to fail. This should fix it.

