### PR TITLE
[i18n] Add all hierarchy names

### DIFF
--- a/src/peliasDocGenerators.js
+++ b/src/peliasDocGenerators.js
@@ -53,7 +53,15 @@ function assignField(hierarchyElement, wofDoc) {
       }
 
       break;
+    default:
+      return;
   }
+
+  _.values(hierarchyElement.name_langs).forEach(names => {
+    names.forEach(name => {
+      wofDoc.addParent(hierarchyElement.place_type, name, hierarchyElement.id.toString());
+    });
+  });
 
 }
 

--- a/test/functional.js
+++ b/test/functional.js
@@ -26,9 +26,11 @@ tape('functional', function(test) {
         t.ok(dbRecords[101772677]);
         t.deepEqual(recordOrder, ['85633147', '1108826387', '85683431', '404227861', '102068587', '404414453', '101772677']);
         t.deepEqual(dbRecords[101772677].parent, {
-          country: ['France'],
+          country: ['France', 'Frankreich','Französische Republik','French',
+                    'French Republic','Furansu','Gallía','République Française',
+                    'Francia','Frankrijk'],
           country_id: ['85633147'],
-          country_a: ['FRA'],
+          country_a: ['FRA',null],
           county: ['Roquemaure'],
           county_id: ['102068587'],
           county_a: [null],
@@ -38,15 +40,17 @@ tape('functional', function(test) {
           locality: ['Tavel'],
           locality_id: ['101772677'],
           locality_a: [null],
-          macrocounty: ['Arrondissement of Nimes'],
+          macrocounty: ['Arrondissement of Nimes','Arrondissement Nîmes',
+                        'arrondissement of Nîmes','arrondissement de Nîmes',
+                        'arrondissement di Nîmes','Distrito de Nîmes'],
           macrocounty_id: ['404227861'],
           macrocounty_a: [null],
-          macroregion: ['Occitanie'],
+          macroregion: ['Occitanie', 'Okzitanien', 'Occitania'],
           macroregion_id: ['1108826387'],
           macroregion_a: [null],
-          region: ['département des Gard'],
+          region: ['département des Gard','Département Gard','Département du Gard'],
           region_id: ['85683431'],
-          region_a: ['GA']
+          region_a: ['GA',null]
         }, 'correct parent hierarchy for Tavel');
         temp.cleanupSync();
         t.end();

--- a/test/peliasDocGeneratorsTest.js
+++ b/test/peliasDocGeneratorsTest.js
@@ -703,6 +703,9 @@ tape('create', function(test) {
         .setNameAlias('fr', 'Pays Du Soleil Levant')
         .setCentroid({ lat: 12.121212, lon: 21.212121 })
         .addParent('country', 'Japan', '1', 'JPN')
+        .addParent('country', 'Nihon', '1')
+        .addParent('country', 'Japon', '1')
+        .addParent('country', 'Pays Du Soleil Levant', '1')
         .setPopularity(25000)
     ];
 


### PR DESCRIPTION
## Background

With pelias/api#1300 I added some cool feature for i18n autocomplete. But there are some limitations, such as the search of `Parijs, Frankrijk`, due to hierarchy index limitation.
Since we have pelias/whosonfirst#446 and the support for multi-lang names property  in OSM, we can search for both OSM venues/addresses and WOF by their non-default/English name.

This means that if we do an autocomplete of `Parijs` (with `lang=nl` and pelias/api#1300) we will get Paris :+1: but if you do an autocomplete of `Parijs, Frankrijk` we will get no results :-1:.

## Why ?

Because the API will search a document with a name property `Parijs` AND in its hierarchy (country, locality...) `Frankrijk`. But in our ES index, we only have the default name in document hierarchy. So `Frankrijk` is not in the `Parijs` hierarchy... Only `France` is present.

## How to get rid of this ? 

We do not have many solutions... I found only 2.

1. We add alternative names in our hierarchy to takes advantage of ES fuzzy search when we autocomplete things.
2. We do 2 requests, my example is for the search of `Pont Neuf, Parijs, Frankrijk`:
    1. The first one is searching ES admin information, something like `source=wof AND (name.lang='Parijs' or name.lang='Frankrijk')` and take their ids.
    2. The second one is searching in ES `Pont Neuf` which is in the hierarchy found lately, something like `name.lang='Pont Neuf' AND (country.id IN ('whosonfirst:country:85633147', 'whosonfirst:locality:101751119') OR locality IN ('whosonfirst:country:85633147', 'whosonfirst:locality:101751119'))`

In this PR I tried the first solution and here are my results for France:

### All names in `parent.placetype`

First try with all names in `parent.placetype` without duplicates.

|   | master  | PR  |
|---|---|---|
| Index Size  |  185M | 1.1G  |
| Index Time  | 86s  | 228s  |

- Pros:
  - `Parijs, Frankrijk` works with pelias/api#1300 and `lang=nl`
- Cons:
  - The index size... 6 times bigger only with WOF data !
  - The payload is bigger when we retrieve documents because we have the full list
  - 2.6 times slower (maybe because of [this](https://github.com/pelias/model/blob/37c4330028dad260038ab05befb81f119f24a67a/Document.js#L329-L331))

This first test is not the right one in my opinion. I will try some alternatives :smile: 

related: pelias/api#1296
related: pelias/api#1300