### PR TITLE
Typo for extraction it should be `lbunzip2`

### DIFF
--- a/utils/download_sqlite_all.js
+++ b/utils/download_sqlite_all.js
@@ -51,9 +51,9 @@ function download(callback) {
   const generateCommand = (sqlite, directory) => {
     let extract;
     if (/\.db\.bz2$/.test(sqlite.name_compressed)) {
-      // Check if we have lbzip2 installed
-      if (commandExistsSync('lbzip2')) {
-        extract = 'lbzip2';
+      // Check if we have lbunzip2 installed
+      if (commandExistsSync('lbunzip2')) {
+        extract = 'lbunzip2';
       } else {
         extract = 'bunzip2';
       }

--- a/utils/sqlite_download.sh
+++ b/utils/sqlite_download.sh
@@ -28,8 +28,8 @@ err() { echo -e "\e[31m[$1]\t\e[0m \e[91m$2\e[0m" >&2; }
 
 # Check if we have lbzip2 (https://lbzip2.org/) installed
 decompress_utility() {
-  if hash lbzip2 2>/dev/null; then
-    lbzip2 -d -f "${LOCAL_BZ2_PATH}" > "${LOCAL_DB_PATH}"
+  if hash lbunzip2 2>/dev/null; then
+    lbunzip2 -d -f "${LOCAL_BZ2_PATH}" > "${LOCAL_DB_PATH}"
   else
     bunzip2 -f "${LOCAL_BZ2_PATH}" > "${LOCAL_DB_PATH}"
   fi


### PR DESCRIPTION
Hi there,

I was testing #487 with the docker image `pelias/whosonfirst:joxit-data-geocode-earth` and I found a little bug ^^'
There is a typo, lbzip2 is for compression. However both lbzip2 and lbunzip2 work for extraction with tar command.