### PR TITLE
refactor(sqliteStream): remove code to generate spr_obsolete index

### DIFF
--- a/src/components/sqliteStream.js
+++ b/src/components/sqliteStream.js
@@ -2,28 +2,9 @@ const Readable = require('stream').Readable;
 const Sqlite3 = require('better-sqlite3');
 const logger = require('pelias-logger').get('whosonfirst:sqliteStream');
 
-// attempt to create index to improve read performance
-//
-// catch all failures since the PIP service will have several processes all
-// trying to acquire a write lock on the DB, and only one will succeed
-//
-// note: can be removed once the upstream PR is merged and all data on
-// dist.whosonfirst.org is updated:
-// https://github.com/whosonfirst/go-whosonfirst-sqlite-features/pull/4
-function createIndex(dbPath) {
-  try {
-    new Sqlite3(dbPath)
-      .exec('CREATE INDEX IF NOT EXISTS spr_obsolete ON spr (is_deprecated, is_superseded)')
-      .close();
-  } catch (e){
-  }
-}
-
 class SQLiteStream extends Readable {
   constructor(dbPath, sql) {
     super({ objectMode: true, autoDestroy: true, highWaterMark: 32 });
-
-    createIndex(dbPath);
 
     this._db = new Sqlite3(dbPath, { readonly: true });
     this._iterator = this._db.prepare(sql).iterate();


### PR DESCRIPTION
A small PR into https://github.com/pelias/whosonfirst/pull/487 which is just https://github.com/pelias/whosonfirst/pull/431.

This code was only required while the canonical SQLite downloads did not include it, it's now being included in all dist files generated by GeocodeEarth via https://github.com/pelias/wof/blob/master/sqlite/table/spr.js#L59
