### PR TITLE
Add tests for module exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,6 @@
 module.exports = {
-  metadataStream: require('./src/components/metadataStream'),
   isActiveRecord: require('./src/components/isActiveRecord').create,
   isNotNullIslandRelated: require('./src/components/isNotNullIslandRelated').create,
-  loadJSON: require('./src/components/loadJSON').create,
-  parseMetaFiles: require('./src/components/parseMetaFiles').create,
   recordHasIdAndProperties: require('./src/components/recordHasIdAndProperties').create,
   recordHasName: require('./src/components/recordHasName').create,
   conformsTo: require('./src/components/conformsTo').create,

--- a/test/module.js
+++ b/test/module.js
@@ -1,0 +1,8 @@
+const tape = require('tape');
+
+const wof_module = require('../');
+
+tape('test the exports of whosonfirst module', function(test) {
+  test.equals(typeof wof_module, 'object');
+  test.end();
+});

--- a/test/test.js
+++ b/test/test.js
@@ -10,5 +10,6 @@ require ('./importStreamTest.js');
 require ('./peliasDocGeneratorsTest.js');
 require ('./readStreamTest.js');
 require ('./schema.js');
+require ('./module.js');
 require ('./bundleList.js');
 require('./functional.js');


### PR DESCRIPTION
This is a PR into #487 which adds some unit tests covering the shared resources exported by this module. We've been bitten many times in the past by removing code and forgetting to update `index.js`. This should help with that going forward.

It also fixes some that were just recently missed :)