### PR TITLE
feat(deps): Remove fs-extra module

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "combined-stream": "^1.0.5",
     "command-exists": "^1.2.9",
     "download-file-sync": "^1.0.4",
-    "fs-extra": "^8.0.0",
     "iso3166-1": "^0.5.0",
     "lodash": "^4.5.1",
     "pelias-blacklist-stream": "^1.0.0",

--- a/src/bundleList.js
+++ b/src/bundleList.js
@@ -1,4 +1,4 @@
-const fs = require('fs-extra');
+const fs = require('fs');
 const path = require('path');
 const _ = require('lodash');
 
@@ -49,7 +49,7 @@ function getPlacetypes() {
 function getDBList(callback) {
   const databasesPath = path.join(peliasConfig.imports.whosonfirst.datapath, 'sqlite');
   //ensure required directory structure exists
-  fs.ensureDirSync(databasesPath);
+  fs.mkdirSync(databasesPath, { recursive: true });
   const dbList = fs.readdirSync(databasesPath).filter(d => SQLITE_REGEX.test(d));
 
   if (_.isEmpty(dbList)) {

--- a/test/bundleList.js
+++ b/test/bundleList.js
@@ -1,6 +1,6 @@
 const tape = require('tape');
 const proxyquire = require('proxyquire');
-const fs = require('fs-extra');
+const fs = require('fs');
 const _ = require('lodash');
 const path = require('path');
 const peliasConfig = require('pelias-config');
@@ -42,6 +42,7 @@ tape('bundlesList tests', (test) => {
 
   test.test('supports sqlite', (t) => {
     temp.mkdir('supports_sqlite', (err, temp_dir) => {
+      fs.mkdirSync(path.join(temp_dir, 'sqlite'), { recursive: true });
       const config = {
         generate: () => {
           return peliasConfig.generateCustom({
@@ -56,7 +57,7 @@ tape('bundlesList tests', (test) => {
       };
       SQLITE_EXAMPLE
         .concat(['ignore_me.csv', 'README.md'])
-        .forEach(e => fs.createFileSync(path.join(temp_dir, 'sqlite', e), ''));
+        .forEach(e => fs.writeFileSync(path.join(temp_dir, 'sqlite', e), ''));
 
       const bundles = proxyquire('../src/bundleList', { 'pelias-config': config });
 

--- a/test/generateWOFDB.js
+++ b/test/generateWOFDB.js
@@ -1,10 +1,10 @@
 const _ = require('lodash');
 const path = require('path');
-const fs = require('fs-extra');
+const fs = require('fs');
 const Sqlite3 = require('better-sqlite3');
 
 module.exports = (dbPath, entries) => {
-  fs.ensureDirSync(path.dirname(dbPath));
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true });
   const db = new Sqlite3(dbPath)
     .exec(`
           CREATE TABLE geojson (

--- a/test/readStreamTest.js
+++ b/test/readStreamTest.js
@@ -1,5 +1,4 @@
 const tape = require('tape');
-const fs = require('fs-extra');
 const path = require('path');
 const temp = require('temp').track();
 const proxyquire = require('proxyquire').noCallThru();

--- a/utils/download_sqlite_all.js
+++ b/utils/download_sqlite_all.js
@@ -1,6 +1,6 @@
 const child_process = require('child_process');
 const async = require('async');
-const fs = require('fs-extra');
+const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const downloadFileSync = require('download-file-sync');
@@ -26,7 +26,7 @@ function getCountriesToDownload() {
 
 function download(callback) {
   //ensure required directory structure exists
-  fs.ensureDirSync(path.join(config.imports.whosonfirst.datapath, 'sqlite'));
+  fs.mkdirSync(path.join(config.imports.whosonfirst.datapath, 'sqlite'), { recursive: true });
 
   // download one bundle for every other CPU (tar and bzip2 can both max out one core)
   // (the maximum is configurable, to keep things from getting too intense, and defaults to 4)


### PR DESCRIPTION
In this project, we only use the fs-extra package for its mkdir -p style convenience wrapper, which can now easily be done with the stock fs module.

This change removes usage of the fs-extra module and replaces it with the native recursive option.

Closes https://github.com/pelias/whosonfirst/pull/489