### PR TITLE
Refresh readme

### DIFF
--- a/src/bundleList.js
+++ b/src/bundleList.js
@@ -8,8 +8,6 @@ const peliasConfig = require( 'pelias-config' ).generate(require('../schema'));
 // lowest level order. See https://github.com/whosonfirst/whosonfirst-placetypes
 // for info on what each bundle type means
 //
-// venue bundle data has to be imported only after all hierarchy bundles are done
-//
 // downloading can be done in any order, but the same order might as well be used
 const hierarchyRoles = [
   'ocean',


### PR DESCRIPTION
Thanks to all the great recent changes, the README has drifted a bit.

This change is the result of a full read through, making things more concise or accurate wherever possible.

In particular, I paid attention to new best practices as a result of our work to support country-specific SQLite downloads. Users are now encouraged to set `countryCode` properly to download only the data they require.