### PR TITLE
Deprecate `importVenues`

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "iso3166-1": "^0.5.0",
     "lodash": "^4.5.1",
     "pelias-blacklist-stream": "^1.0.0",
-    "pelias-config": "^4.9.1",
+    "pelias-config": "^4.10.0",
     "pelias-dbclient": "^2.13.0",
     "pelias-logger": "^1.2.1",
     "pelias-model": "^7.1.0",

--- a/schema.js
+++ b/schema.js
@@ -25,7 +25,6 @@ module.exports = Joi.object().keys({
         Joi.number().integer(),
         Joi.array().items(Joi.number().integer())
       ],
-      importVenues: Joi.boolean().default(false).truthy('yes').falsy('no'),
       importPostalcodes: Joi.boolean().default(false).truthy('yes').falsy('no'),
       importConstituencies: Joi.boolean().default(false).truthy('yes').falsy('no'),
       maxDownloads: Joi.number().integer(),


### PR DESCRIPTION
BREAKING CHANGE: Because we do not expect Who's on First to update venue data, and we will likely never publish that data to the new data host from Geocode Earth, the `importVenues` option is now deprecated.

Connects https://github.com/pelias/whosonfirst/issues/94