### PR TITLE
fix(doc): Do not allow duplicate names to be created

### DIFF
--- a/src/peliasDocGenerators.js
+++ b/src/peliasDocGenerators.js
@@ -88,7 +88,9 @@ function setupDocument(record, hierarchy) {
     else {
       if (record.name_aliases.length) {
         record.name_aliases.forEach(alias => {
-          wofDoc.setNameAlias('default', alias);
+          if (alias !== record.name) {
+            wofDoc.setNameAlias('default', alias);
+          }
         });
       }
       if (record.name_langs) {


### PR DESCRIPTION
While diagnosing an issue related to scoring, I discovered that WOF records are sometimes created with duplicate name values. While the pelias/model code can detect some of them (and more will be fixed with https://github.com/pelias/model/pull/132), we could also fix this issue at the source.

Here's an example of what a document might look like today, before this PR:

```
{
  name: { default: [ 'Kansas City' ] },
  phrase: { default: [ 'Kansas City', 'Kansas City' ] },
  ...
}
```

This can be fixed by checking each potential alternate name against the "primary" name value.

We might not want to merge this PR, since it only fixes the issue in this repo, but it might also be nice to test this change in a single repository first.