### PR TITLE
fix(deps): Upgrade pelias-model to 7.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "pelias-config": "^4.10.0",
     "pelias-dbclient": "^2.13.0",
     "pelias-logger": "^1.2.1",
-    "pelias-model": "^7.1.0",
+    "pelias-model": "^7.2.1",
     "through2": "^3.0.0",
     "through2-filter": "^3.0.0",
     "through2-map": "^3.0.0",


### PR DESCRIPTION
This should help fix some scoring issues identified in https://github.com/pelias/whosonfirst/pull/511

While not a complete fix, it should mitigate the effects of https://github.com/pelias/openstreetmap/issues/507 somewhat.