### PR TITLE
add Pelias UserAgent to cURL requests

### DIFF
--- a/utils/download_sqlite_all.js
+++ b/utils/download_sqlite_all.js
@@ -14,6 +14,10 @@ const wofDataHost = config.get('imports.whosonfirst.dataHost') || DATA_GEOCODE_E
 const COMBINED_REGEX = /^whosonfirst-data-(admin|postalcode)-latest/;
 const COUNTRY_REGEX = /^whosonfirst-data-(admin|postalcode)-[a-z]{2}-latest/;
 
+// generate a User Agent string to identify downloads as originating from Pelias tools
+const pkg = require('../package.json');
+const agent = `${pkg.name}/${pkg.version}`;
+
 function on_done() {
   logger.info('All done!');
 }
@@ -94,7 +98,12 @@ function download(callback) {
       throw new Error('What is this extension ?!?');
     }
 
-    return `curl -s ${wofDataHost}/sqlite/${sqlite.name_compressed} | ${extract} > ${path.join(directory, 'sqlite', sqlite.name)}`;
+    return [
+      `curl -sA '${agent}'`,
+      `${wofDataHost}/sqlite/${sqlite.name_compressed}`,
+      '|', extract,
+      '>', path.join(directory, 'sqlite', sqlite.name)
+    ].join(' ');
   };
 
   const downloadFunctions = generateSQLites().map(function (sqlite) {


### PR DESCRIPTION
The Geocode Earth CDN has become fairly popular, we served >15TB to Europe alone last month :rocket:

I'd like to have a little more information about who's using the CDN as I suspect that there are some systems out there downloading the data over-and-over-again in automated scripts.

This PR is pretty simple, it just adds an HTTP User Agent string to download requests made from Pelias tooling so we can distinguish the Pelias traffic from the non-Pelias traffic.

Here's an example from the logs:

![Screenshot 2020-07-21 at 10 45 58](https://user-images.githubusercontent.com/738069/88034390-ecd5c700-cb40-11ea-9242-c46c7890178b.png)

note: I unfortunately had to break the long line for the return statement in `generateCommand()` because the linter complained, I made it an Array to get around that but it still seems wrong to me..

<img width="535" alt="Screenshot 2020-07-21 at 10 52 33" src="https://user-images.githubusercontent.com/738069/88034659-4d650400-cb41-11ea-9664-52362804bf95.png">

