### PR TITLE
Upgrade to pelias-model 8.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "pelias-config": "^4.10.0",
     "pelias-dbclient": "^2.13.0",
     "pelias-logger": "^1.2.1",
-    "pelias-model": "^7.2.1",
+    "pelias-model": "^8.0.0",
     "through2": "^3.0.0",
     "through2-filter": "^3.0.0",
     "through2-map": "^3.0.0",


### PR DESCRIPTION
This fixes an incorrect model function that was expecting a property called `polygon` in the Elasticsearch schema. The correct property is `shape`.

See https://github.com/pelias/model/pull/134