### PR TITLE
unit test failure with pelias/model upgrade

### DIFF
--- a/test/readStreamTest.js
+++ b/test/readStreamTest.js
@@ -117,7 +117,7 @@ tape('readStream', (test) => {
         const xyMessages = logger.getDebugMessages().filter(m => m.indexOf('whosonfirst-data-admin-xy-latest.db') >= 0);
         const xxMessages = logger.getDebugMessages().filter(m => m.indexOf('whosonfirst-data-admin-xx-latest.db') >= 0);
 
-        t.deepEquals(xyMessages.length, 17);
+        t.deepEquals(xyMessages.length, 16);
         t.deepEquals(xyMessages.length, xxMessages.length);
         t.end();
       });
@@ -195,7 +195,7 @@ tape('readStream', (test) => {
               hierarchies: [ { 'region_id': 421302191 } ]
             }
           });
-          t.deepEqual(logger.getDebugMessages().length, 17);
+          t.deepEqual(logger.getDebugMessages().length, 16);
           t.end();
         });
     });


### PR DESCRIPTION
when working on an unrelated feature I noticed that updating `pelias/model` resulted in a broken test.

I believe this is due to https://github.com/pelias/config/pull/135 removing a duplicate entry for `continent`?

@orangejulius could you please sanity check this for me?

```bash
    operator: deepEqual
    expected: 17
    actual:   16
    at: DestroyableTransform.<anonymous> (/Users/peter/code/pelias/whosonfirst/test/readStreamTest.js:123:11)
    stack: |-
           Error: should be deeply equivalent
             at Test.assert [as _assert] (/Users/peter/code/pelias/whosonfirst/node_modules/tape/lib/test.js:304:54)
             at Test.bound [as _assert] (/Users/peter/code/pelias/whosonfirst/node_modules/tape/lib/test.js:91:32)
             at Test.tapeDeepEqual (/Users/peter/code/pelias/whosonfirst/node_modules/tape/lib/test.js:545:10)
             at Test.bound [as deepEquals] (/Users/peter/code/pelias/whosonfirst/node_modules/tape/lib/test.js:91:32)
             at DestroyableTransform.<anonymous> (/Users/peter/code/pelias/whosonfirst/test/readStreamTest.js:123:11)
             at DestroyableTransform.emit (node:events:381:22)
             at finishMaybe (/Users/peter/code/pelias/whosonfirst/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:624:14)
             at endWritable (/Users/peter/code/pelias/whosonfirst/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:643:3)
             at DestroyableTransform.Writable.end (/Users/peter/code/pelias/whosonfirst/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:571:22)
             at Through2.onend (/Users/peter/code/pelias/whosonfirst/node_modules/through2-filter/node_modules/readable-stream/lib/_stream_readable.js:577:10)
```