### PR TITLE
Remove unnecessary compiler toolchain dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM pelias/baseimage
 
 # downloader apt dependencies
 # note: this is done in one command in order to keep down the size of intermediate containers
-RUN apt-get update && apt-get install -y autoconf automake libtool pkg-config python bzip2 lbzip2 unzip && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y bzip2 lbzip2 unzip && rm -rf /var/lib/apt/lists/*
 
 # change working dir
 ENV WORKDIR /code/pelias/whosonfirst


### PR DESCRIPTION
After `better-sqlite3` added support for pre-compiled binaries in [v6](https://github.com/JoshuaWise/better-sqlite3/releases/tag/v6.0.0), we no longer need to install a compiler toolchain to run `npm install` in our Docker images.

https://github.com/pelias/docker-baseimage/pull/23 removes the compiler toolchain from our Pelias baseimages. In order for the toolchain to be removed from the whosonfirst image in particular, we also need to remove those dependencies here.

Until that PR is merged, this change is effectively a no-op. After, between the two PRs we reduce the size of the whosonfirst docker image from 490MB to 261MB, an impressive 221MB savings!