### PR TITLE
Avoid crash during import by bumping memory limit to 8GB

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-exec node --max_old_space_size=6000 import.js
+exec node --max_old_space_size=8000 import.js


### PR DESCRIPTION
This crash just started happening for me, though it's been maybe a month since I last tried a planet import.

---
#### Here's the reason for this change :rocket:

When importing the planet dataset (via docker), I hit a crash part way through the WOF import. In other repositories, this has been handled by gradually bumping node's memory limits, so I'm assuming the same is OK here as WOF continues to grow.

- [bump csv-importer to 6GB](https://github.com/pelias/csv-importer/commit/2ec1146497be7251e7d895d5bef0e53cb914a667)
- [bump wof to 6000](https://github.com/pelias/whosonfirst/commit/dbb24d0ec6ada6f40b66bf8cc49793aef905c446)
- [bump openaddreses to 6GB](https://github.com/pelias/openaddresses/commit/99bfa1e70e51b773380c39a0b94da5c183d5626e)
- [bump openaddreses to 8GB](https://github.com/pelias/openaddresses/commit/efa7209b5a1fc60f464bd4915652012f99548fdb)

```
| info: [dbclient-whosonfirst]  paused=true, transient=5, current_length=0, indexed=5329500, batch_ok=10659, batch_retries=0, failed_records=0, region=4186, ocean=7, marinearea=402, continent=8, empire=21, country=213, dependency=40, disputed=205, macroregion=99, persec=1050, macrocounty=478, county=41686, localadmin=138493, locality=4861126, borough=461, macrohood=1232, neighbourhood=280843
| <--- Last few GCs --->
| [1:0x5d39450]  3812811 ms: Scavenge 4872.9 (6017.4) -> 4866.3 (6020.2) MB, 13.2 / 0.0 ms  (average mu = 0.175, current mu = 0.171) allocation failure
| [1:0x5d39450]  3812858 ms: Scavenge 4877.7 (6020.2) -> 4871.1 (6022.7) MB, 13.4 / 0.0 ms  (average mu = 0.175, current mu = 0.171) allocation failure
| [1:0x5d39450]  3812903 ms: Scavenge 4882.5 (6022.7) -> 4875.9 (6025.7) MB, 13.2 / 0.0 ms  (average mu = 0.175, current mu = 0.171) allocation failure
| <--- JS stacktrace --->
| FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
|  1: 0xb090e0 node::Abort() [node]
|  2: 0xa1b70e  [node]
|  3: 0xce1a20 v8::Utils::ReportOOMFailure(v8::internal::Isolate*, char const*, bool) [node]
|  4: 0xce1dc7 v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, bool) [node]
|  5: 0xe99435  [node]
|  6: 0xe99f16  [node]
|  7: 0xea843e  [node]
|  8: 0xea8e80 v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags) [node]
|  9: 0xeabdfe v8::internal::Heap::AllocateRawWithRetryOrFailSlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [node]
| 10: 0xe6d1af v8::internal::Factory::AllocateRawWithAllocationSite(v8::internal::Handle<v8::internal::Map>, v8::internal::AllocationType, v8::internal::Handle<v8::internal::AllocationSite>) [node]
| 11: 0xe74adc v8::internal::Factory::NewJSObjectFromMap(v8::internal::Handle<v8::internal::Map>, v8::internal::AllocationType, v8::internal::Handle<v8::internal::AllocationSite>) [node]
| 12: 0xe75105 v8::internal::Factory::NewJSArrayWithUnverifiedElements(v8::internal::Handle<v8::internal::FixedArrayBase>, v8::internal::ElementsKind, int, v8::internal::AllocationType) [node]
| 13: 0xe75372 v8::internal::Factory::NewJSArray(v8::internal::ElementsKind, int, int, v8::internal::ArrayStorageAllocationMode, v8::internal::AllocationType) [node]
| 14: 0xf85341 v8::internal::JsonParser<unsigned short>::BuildJsonArray(v8::internal::JsonParser<unsigned short>::JsonContinuation const&, v8::base::SmallVector<v8::internal::Handle<v8::internal::Object>, 16ul> const&) [node]
| 15: 0xf8cf84 v8::internal::JsonParser<unsigned short>::ParseJsonValue() [node]
| 16: 0xf8dd7f v8::internal::JsonParser<unsigned short>::ParseJson() [node]
| 17: 0xd6394b v8::internal::Builtin_JsonParse(int, unsigned long*, v8::internal::Isolate*) [node]
| 18: 0x15d9f39  [node]
```
---

#### Here's how others can test the changes :eyes:

I ran the planet import in docker, but haven't tried anything outside of that context.