### PR TITLE
move away from event-stream, replace with stream-mock

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,11 +44,11 @@
     "through2-sink": "^1.0.0"
   },
   "devDependencies": {
-    "event-stream": "^4.0.0",
     "jshint": "^2.5.6",
     "pelias-mock-logger": "^1.1.0",
     "precommit-hook": "^3.0.0",
     "proxyquire": "^2.0.0",
+    "stream-mock": "^2.0.5",
     "tap-dot": "^2.0.0",
     "tape": "^5.0.0",
     "temp": "^0.9.0"

--- a/test/components/conformsTo.js
+++ b/test/components/conformsTo.js
@@ -1,13 +1,14 @@
 const tape = require('tape');
-const event_stream = require('event-stream');
+const stream_mock = require('stream-mock');
 
 const conformsTo = require('../../src/components/conformsTo');
 
 function test_stream(input, testedStream, callback) {
-    const input_stream = event_stream.readArray(input);
-    const destination_stream = event_stream.writeArray(callback);
-
-    input_stream.pipe(testedStream).pipe(destination_stream);
+  const reader = new stream_mock.ObjectReadableMock(input);
+  const writer = new stream_mock.ObjectWritableMock();
+  writer.on('error', (e) => callback(e));
+  writer.on('finish', () => callback(null, writer.data));
+  reader.pipe(testedStream).pipe(writer);
 }
 
 tape('conformsTo', (test) => {

--- a/test/components/extractFieldsTest.js
+++ b/test/components/extractFieldsTest.js
@@ -1,5 +1,5 @@
 var tape = require('tape');
-var event_stream = require('event-stream');
+const stream_mock = require('stream-mock');
 
 var extractFields = require('../../src/components/extractFields');
 
@@ -14,10 +14,11 @@ var extractFields = require('../../src/components/extractFields');
  * Callback signature should be something like function callback(error, result)
  */
 function test_stream(input, testedStream, callback) {
-    var input_stream = event_stream.readArray(input);
-    var destination_stream = event_stream.writeArray(callback);
-
-    input_stream.pipe(testedStream).pipe(destination_stream);
+  const reader = new stream_mock.ObjectReadableMock(input);
+  const writer = new stream_mock.ObjectWritableMock();
+  writer.on('error', (e) => callback(e));
+  writer.on('finish', () => callback(null, writer.data));
+  reader.pipe(testedStream).pipe(writer);
 }
 
 tape('readStreamComponents', function(test) {

--- a/test/components/isActiveRecordTest.js
+++ b/test/components/isActiveRecordTest.js
@@ -1,13 +1,14 @@
 var tape = require('tape');
-var event_stream = require('event-stream');
+const stream_mock = require('stream-mock');
 
 var isActiveRecord = require('../../src/components/isActiveRecord');
 
 function test_stream(input, testedStream, callback) {
-    var input_stream = event_stream.readArray(input);
-    var destination_stream = event_stream.writeArray(callback);
-
-    input_stream.pipe(testedStream).pipe(destination_stream);
+  const reader = new stream_mock.ObjectReadableMock(input);
+  const writer = new stream_mock.ObjectWritableMock();
+  writer.on('error', (e) => callback(e));
+  writer.on('finish', () => callback(null, writer.data));
+  reader.pipe(testedStream).pipe(writer);
 }
 
 tape('isActiveRecord', function(test) {

--- a/test/components/isNotNullIslandRelated.js
+++ b/test/components/isNotNullIslandRelated.js
@@ -1,13 +1,14 @@
 const tape = require('tape');
-const event_stream = require('event-stream');
+const stream_mock = require('stream-mock');
 
 const isNotNullIslandRelated = require('../../src/components/isNotNullIslandRelated');
 
 function test_stream(input, testedStream, callback) {
-    var input_stream = event_stream.readArray(input);
-    var destination_stream = event_stream.writeArray(callback);
-
-    input_stream.pipe(testedStream).pipe(destination_stream);
+  const reader = new stream_mock.ObjectReadableMock(input);
+  const writer = new stream_mock.ObjectWritableMock();
+  writer.on('error', (e) => callback(e));
+  writer.on('finish', () => callback(null, writer.data));
+  reader.pipe(testedStream).pipe(writer);
 }
 
 tape('isNotNullIslandRelated tests', (test) => {

--- a/test/components/recordHasIdAndPropertiesTest.js
+++ b/test/components/recordHasIdAndPropertiesTest.js
@@ -1,13 +1,14 @@
 var tape = require('tape');
-var event_stream = require('event-stream');
+const stream_mock = require('stream-mock');
 
 var recordHasIdAndProperties = require('../../src/components/recordHasIdAndProperties');
 
 function test_stream(input, testedStream, callback) {
-    var input_stream = event_stream.readArray(input);
-    var destination_stream = event_stream.writeArray(callback);
-
-    input_stream.pipe(testedStream).pipe(destination_stream);
+  const reader = new stream_mock.ObjectReadableMock(input);
+  const writer = new stream_mock.ObjectWritableMock();
+  writer.on('error', (e) => callback(e));
+  writer.on('finish', () => callback(null, writer.data));
+  reader.pipe(testedStream).pipe(writer);
 }
 
 tape('recordHasIdAndProperties', function(test) {

--- a/test/components/recordHasNameTest.js
+++ b/test/components/recordHasNameTest.js
@@ -1,13 +1,14 @@
 var tape = require('tape');
-var event_stream = require('event-stream');
+var stream_mock = require('stream-mock');
 
 var recordHasName = require('../../src/components/recordHasName');
 
 function test_stream(input, testedStream, callback) {
-    var input_stream = event_stream.readArray(input);
-    var destination_stream = event_stream.writeArray(callback);
-
-    input_stream.pipe(testedStream).pipe(destination_stream);
+  const reader = new stream_mock.ObjectReadableMock(input);
+  const writer = new stream_mock.ObjectWritableMock();
+  writer.on('error', (e) => callback(e));
+  writer.on('finish', () => callback(null, writer.data));
+  reader.pipe(testedStream).pipe(writer);
 }
 
 tape('recordHasName', function(test) {

--- a/test/importStreamTest.js
+++ b/test/importStreamTest.js
@@ -3,13 +3,14 @@ var importStream = require('../src/importStream');
 var sink = require('through2-sink');
 var Document = require('pelias-model').Document;
 var map_stream = require('through2-map');
-var event_stream = require('event-stream');
+const stream_mock = require('stream-mock');
+
 
 tape('importStream', function(test) {
   test.test('all wofRecords should be converted to Documents and sent to destination', function(t) {
     var docs = [];
 
-    var recordStream = event_stream.readArray([
+    var recordStream = new stream_mock.ObjectReadableMock([
       { id: 1, place_type: 'placetype 1' },
       { id: 2, place_type: 'placetype 2' },
       { id: 3, place_type: 'placetype 3' },

--- a/test/peliasDocGeneratorsTest.js
+++ b/test/peliasDocGeneratorsTest.js
@@ -1,13 +1,14 @@
 var tape = require('tape');
 var Document = require('pelias-model').Document;
 var peliasDocGenerators = require('../src/peliasDocGenerators');
-var event_stream = require('event-stream');
+const stream_mock = require('stream-mock');
 
 function test_stream(input, testedStream, callback) {
-    var input_stream = event_stream.readArray(input);
-    var destination_stream = event_stream.writeArray(callback);
-
-    input_stream.pipe(testedStream).pipe(destination_stream);
+  const reader = new stream_mock.ObjectReadableMock(input);
+  const writer = new stream_mock.ObjectWritableMock();
+  writer.on('error', (e) => callback(e));
+  writer.on('finish', () => callback(null, writer.data));
+  reader.pipe(testedStream).pipe(writer);
 }
 
 tape('create', function(test) {


### PR DESCRIPTION
#### Here's the reason for this change :rocket:

Part of https://github.com/pelias/pelias/issues/801

#### Here's what actually got changed :clap:

Technique cribbed from https://github.com/pelias/openaddresses/pull/457

#### Here's how others can test the changes :eyes:

I ran the tests before and after this change with a fresh npm install.