### PR TITLE
correctly display string-typed errors

### DIFF
--- a/import.js
+++ b/import.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 var peliasConfig = require( 'pelias-config' ).generate(require('./schema'));
 var readStreamModule = require('./src/readStream');
 var importStream = require('./src/importStream');
@@ -15,7 +16,7 @@ var wofAdminRecords = {};
 bundles.generateBundleList((err, bundlesToImport) => {
 
   if (err) {
-    throw new Error(err.message);
+    throw (_.isError(err) ? err : new Error(err));
   }
 
   // This can be either csv or db files, the read stream module will do the job


### PR DESCRIPTION
The errors generated in https://github.com/pelias/whosonfirst/blob/master/src/bundleList.js are of type `string`, when combined with throwing `err.message` no error message was printed to the terminal.

This PR improves the error reporting by throwing the original error (if of type Error), else wrapping the string in a new Error object, although the latter method loses stack info.

related https://github.com/pelias/docker/issues/334