### PR TITLE
update better-sqlite3 to work with node@v22

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -7,7 +7,7 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-        node-version: [ 18.x, 20.x ]
+        node-version: [ 18.x, 20.x , 22.x ]
     steps:
       - uses: actions/checkout@v4
       - name: 'Install node.js ${{ matrix.node-version }}'

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM pelias/baseimage
 RUN apt-get update && apt-get install -y bzip2 lbzip2 unzip && rm -rf /var/lib/apt/lists/*
 
 # change working dir
-ENV WORKDIR /code/pelias/whosonfirst
+ENV WORKDIR=/code/pelias/whosonfirst
 WORKDIR ${WORKDIR}
 
 # copy package.json first to prevent npm install being rerun when only code changes

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@hapi/joi": "^16.1.8",
     "async": "^3.0.1",
-    "better-sqlite3": "^8.5.0",
+    "better-sqlite3": "^11.5.0",
     "combined-stream": "^1.0.5",
     "command-exists": "^1.2.9",
     "download-file-sync": "^1.0.4",


### PR DESCRIPTION
update better-sqlite3 to work with node@v22

package `pelias-wof-admin-lookup` depends on this module, which in turn is depended on by `pelias-csv-importer`, so fixing it here will resolve the issues on the downstream modules.

https://github.com/pelias/pelias/issues/950