### PR TITLE
fix for duplicate documents sharing the same ID

### DIFF
--- a/src/hierarchyFinder.js
+++ b/src/hierarchyFinder.js
@@ -1,13 +1,3 @@
-module.exports = {};
-
-var hasName = function(r) {
-  return r.name;
-};
-
-var isDefined = function(r) {
-  return r;
-};
-
 /*
   This function finds all the WOF records associated with a hierarchy
 
@@ -26,24 +16,20 @@ var isDefined = function(r) {
   ]
 
   lastly, filter out any hierarchy elements that are undefined or w/o a name
-
 */
-function resolveHierarchy(wofRecords, hierarchy) {
-  return Object.keys(hierarchy).map(function(key) {
-    return wofRecords[hierarchy[key]];
-  }).filter(isDefined).filter(hasName);
-}
 
 /*
  This function returns all the resolved hierarchies for a wofRecord.  Each
  wofRecord can have multiple hierarchies, so resolve them by looking up the
- referenced wofRecord in the big collection of wofRecords.
+ referenced wofRecord in the big collection of parentRecords.
 */
-module.exports = function(wofRecords) {
-  return function(wofRecord) {
-    return wofRecord.hierarchies.reduce(function(resolvedHierarchies, hierarchy) {
-      resolvedHierarchies.push(resolveHierarchy(wofRecords, hierarchy));
-      return resolvedHierarchies;
-    }, []);
+module.exports = (parentRecords) => {
+  return (wofRecord) => {
+    return wofRecord.hierarchies.map(hierarchy => {
+      return Object.values(hierarchy)
+        .map(parentId => parentRecords[parentId])
+        .filter(Boolean)
+        .filter(r => r.name);
+    });
   };
 };

--- a/src/peliasDocGenerators.js
+++ b/src/peliasDocGenerators.js
@@ -151,18 +151,16 @@ function setupDocument(record, hierarchy) {
 
 }
 
-module.exports.create = function(hierarchy_finder) {
-  return through2.obj(function(record, enc, next) {
-    // if there are no hierarchies, then just return the doc as-is
-    var hierarchies = hierarchy_finder(record);
+module.exports.create = (hierarchy_finder) => {
+  return through2.obj(function(record, _enc, next) {
+    const hierarchies = hierarchy_finder(record);
 
     try {
-      if (hierarchies && hierarchies.length > 0) {
-        hierarchies.forEach(function(hierarchy) {
-          this.push(setupDocument(record, hierarchy));
-        }, this);
-
+      if (Array.isArray(hierarchies) && hierarchies.length > 0) {
+        // only use the first hierarchy when multiple hierarchies exist
+        this.push(setupDocument(record, hierarchies[0]));
       } else {
+        // if there are no hierarchies, then just return the doc as-is
         this.push(setupDocument(record));
       }
     }

--- a/test/peliasDocGeneratorsTest.js
+++ b/test/peliasDocGeneratorsTest.js
@@ -579,7 +579,7 @@ tape('create', function(test) {
 
   });
 
-  test.test('a document should be created for each available hierarchy', function(t) {
+  test.test('a single document should be created when multiple hierarchies exist', function(t) {
     var wofRecords = {
       1: {
         id: 1,
@@ -619,11 +619,6 @@ tape('create', function(test) {
         .setCentroid({ lat: 12.121212, lon: 21.212121 })
         .addParent( 'neighbourhood', 'neighbourhood name', '1')
         .addParent( 'country', 'country name 1', '2'),
-      new Document( 'whosonfirst', 'neighbourhood', '1')
-        .setName('default', 'neighbourhood name')
-        .setCentroid({ lat: 12.121212, lon: 21.212121 })
-        .addParent( 'neighbourhood', 'neighbourhood name', '1')
-        .addParent( 'country', 'country name 2', '3')
     ];
 
     var hierarchies_finder = function() {


### PR DESCRIPTION
a very old PR introduced functionality to generate multiple versions of the same document for each hierarchy present. However, all the documents used the same ID in Elasticsearch. This results in all document being overwritten in Elasticsearch with the document with the _last_ hierarchy.

While there isn't always a strong preferred order, generally we want the _first_ hierarchy.

reverts https://github.com/pelias/whosonfirst/pull/87