### PR TITLE
Remove compression tools now included in baseimage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
 # base image
 FROM pelias/baseimage
 
-# downloader apt dependencies
-# note: this is done in one command in order to keep down the size of intermediate containers
-RUN apt-get update && apt-get install -y bzip2 lbzip2 unzip && rm -rf /var/lib/apt/lists/*
-
 # change working dir
 ENV WORKDIR=/code/pelias/whosonfirst
 WORKDIR ${WORKDIR}


### PR DESCRIPTION
These are already present after https://github.com/pelias/docker-baseimage/pull/33