### PR TITLE
Upgrade better-sqlite3 to v12.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@hapi/joi": "^16.1.8",
     "async": "^3.0.1",
-    "better-sqlite3": "^11.5.0",
+    "better-sqlite3": "^12.2.0",
     "combined-stream": "^1.0.5",
     "command-exists": "^1.2.9",
     "download-file-sync": "^1.0.4",


### PR DESCRIPTION
This adds support for Node.js 24!