### PR TITLE
Upgrade to joi v18

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/pelias/whosonfirst#readme",
   "dependencies": {
-    "@hapi/joi": "^16.1.8",
+    "joi": "^18.0.0",
     "async": "^3.0.1",
     "better-sqlite3": "^12.2.0",
     "combined-stream": "^1.0.5",

--- a/schema.js
+++ b/schema.js
@@ -1,4 +1,4 @@
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 
 // Schema Configuration
 // required:
@@ -21,10 +21,10 @@ module.exports = Joi.object().keys({
       ).default([]),
       dataHost: Joi.string(),
       datapath: Joi.string().required(),
-      importPlace: [
+      importPlace: Joi.alternatives().try(
         Joi.number().integer(),
         Joi.array().items(Joi.number().integer())
-      ],
+      ),
       importPostalcodes: Joi.boolean().default(false).truthy('yes').falsy('no'),
       importConstituencies: Joi.boolean().default(false).truthy('yes').falsy('no'),
       maxDownloads: Joi.number().integer(),

--- a/test/schema.js
+++ b/test/schema.js
@@ -1,7 +1,7 @@
 
 const tape = require('tape');
 
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const schema = require('../schema');
 
 function validate(config) {


### PR DESCRIPTION
This is a bit of a test of moving towards https://github.com/pelias/whosonfirst/issues/537. We've been on an old version of Joi for quite a long time. Since then the package has had new versions, and has moved from the `@hapi` scope to unscoped.

The upgrade isn't very difficult, just one minor change to the schema syntax to handle `importPlace` accepting a single number or an array of numbers.

By itself this PR won't do much to fix any warnings, but we can make similar PRs in pelias/config and elswhere to get moving in the right direction.

I tested an import with this change and it works as expected.
